### PR TITLE
Linkify all navigation

### DIFF
--- a/app/elements/app-link/app-link.html
+++ b/app/elements/app-link/app-link.html
@@ -2,6 +2,9 @@
 Polymer({
   is: 'app-link',
   extends: 'a',
+  properties: {
+    skipNav: Boolean
+  },
   listeners: {
     'click': 'navigate'
   },
@@ -11,8 +14,7 @@ Polymer({
       return true;
     } else {
       e.preventDefault();
-      e.stopPropagation();
-      this.fire('nav', {url: this.href});
+      if (!this.skipNav) this.fire('nav', {url: this.href});
     }
   }
 });

--- a/app/elements/element-table/element-table.html
+++ b/app/elements/element-table/element-table.html
@@ -141,11 +141,20 @@ Polymer({
     e.stopPropagation();
     this.fire('tag-selected', {name: e.currentTarget.name});
   },
-  nav: function(e) {
-    e.preventDefault();
+  nav: function(e, detail) {
     e.stopPropagation();
-    var el = e.currentTarget.getAttribute('target');
-    this.fire('nav',{url: "/elements/" + el});
+    e.preventDefault();
+
+    var se = detail.sourceEvent || {};
+    var url = "/elements/" + e.currentTarget.getAttribute('target');
+    if (se.ctrlKey || se.metaKey) {
+      window.open(url);
+    } else {
+      this.fire('nav', {url: url});
+    }
   },
+  _elementLink: function(name) {
+    return "/elements/" + name;
+  }
 });
 </script>

--- a/app/elements/package-tile/package-tile.css
+++ b/app/elements/package-tile/package-tile.css
@@ -111,6 +111,7 @@ hr {
   font-size: 13px;
   margin: 10px 0 0 0;
   line-height: 20px;
+  height: 40px;
 }
 
 :host(.active) .tagline {

--- a/app/elements/pages/page-browse.css
+++ b/app/elements/pages/page-browse.css
@@ -226,7 +226,7 @@ app-sidebar paper-toolbar {
   border-width: 1px 0;
 }
 
-#package-list .package.iron-selected {
+#package-list .package[active] {
   background: var(--paper-blue-grey-50);
   border-color: var(--paper-blue-grey-100);
 }

--- a/app/elements/pages/page-browse.html
+++ b/app/elements/pages/page-browse.html
@@ -41,22 +41,22 @@
             </div>
             <div id="package-list">
               <h5>Products</h5>
-              <iron-selector attr-for-selected="name" selected="{{package}}" on-iron-activate="closeDrawer">
-                <div class="package" name="">
+              <nav>
+                <a class="package" is="app-link" href="/browse?package=" active$="[[_isEqual(package,'')]]">
                   <div class="layout horizontal center">
                     <div class="all-symbol"><iron-icon icon="apps"></iron-icon></div>
                     <span class="title flex">All Elements</span>
                   </div>
-                </div>
+                </a>
                 <template is="dom-repeat" items="[[packages]]">
-                  <div class="package" name="[[item.name]]">
+                  <a class="package" is="app-link" href$="[[_packageLink(item.name)]]" active$="[[_isEqual(package,item.name)]]">
                     <div class="layout horizontal center">
                       <package-symbol package="[[item]]"></package-symbol>
                       <span class="title flex">[[item.title]]</span>
                     </div>
-                  </div>
+                  </a>
                 </template>
-              </iron-selector>
+              </nav>
             </div>
             <div id="tags">
               <!--<h5>Tags</h5>-->
@@ -75,7 +75,7 @@
                 </div>
                 <div class="section">
                   <h5>Tags</h5>
-  
+
                 </div>
               </div>
             </div>-->
@@ -84,7 +84,7 @@
             </div>
           </div>
         </app-sidebar>
-  
+
         <div id="container" class="fit" view$="[[_actualView(view,_narrowViewport)]]" main>
           <div class="elements-title horizontal layout center">
             <iron-icon icon="menu" paper-drawer-toggle></iron-icon>
@@ -92,11 +92,11 @@
             <iron-icon id="package-view-mode" icon="[[viewIcon]]" on-tap="toggleView" hidden$="[[_forceCards]]"></iron-icon>
             <iron-icon id="cart-toggle" icon="shopping-cart" on-tap="cartOpen"></iron-icon>
           </div>
-  
+
           <div id="package-heading" hidden$="[[!packageInfo]]">
             <div class="description">[[packageInfo.description]]</div>
           </div>
-  
+
           <div id="element-cards" class="horizontal layout wrap">
             <template is="dom-if" if="[[_stampCards(view,_forceCards)]]">
               <template name="element-cards-repeat" is="dom-repeat" items="[[_filteredElements]]">
@@ -104,7 +104,7 @@
               </template>
             </template>
           </div>
-  
+
           <template is="dom-if" if="[[_stampTable(view,_forceCards)]]">
             <element-table elements="[[_filteredElements]]" on-tag-selected="updateTag"></element-table>
           </template>
@@ -231,6 +231,9 @@
           this[key] = params[key];
         }
       },
+      _packageLink: function(name) {
+        return "/browse?package=" + name;
+      },
       updateSearch: function() {
         var params = this._parseQueryString();
         if (params && params.q) {
@@ -320,6 +323,9 @@
       },
       _updateForceCards: function() {
         this._forceCards = this._narrowViewport || this._detectIEVersion() > 0;
+      },
+      _isEqual: function(a,b) {
+        return a === b;
       }
     });
   })();

--- a/app/elements/pages/page-element.css
+++ b/app/elements/pages/page-element.css
@@ -68,14 +68,13 @@ app-sidebar paper-toolbar {
   display: none;
 }
 
-paper-item {
-  cursor: pointer;
-}
-
-paper-item {
+paper-item, a.item {
+  display: block;
   font-size: 14px;
   padding: 4px 16px;
   min-height: inherit;
+  cursor: pointer;
+  font-weight: 400;
 }
 
 .nav {
@@ -89,7 +88,7 @@ paper-item {
   margin-right: 8px;
 }
 
-.nav .iron-selected {
+.nav [active] {
   background: var(--paper-blue-grey-50);
 }
 

--- a/app/elements/pages/page-element.html
+++ b/app/elements/pages/page-element.html
@@ -32,11 +32,11 @@
             <app-bar class="horizontal layout center end-justified" query="{{q}}"></app-bar>
           </paper-toolbar>
           <div class="content">
-            <div class="horizontal layout center" id="package-heading" on-tap="navToPackage">
+            <a is="app-link" href="[[_packageLink(package.name)]]" class="horizontal layout center" id="package-heading">
               <iron-icon icon="chevron-left"></iron-icon>
               <package-symbol package="[[package]]"></package-symbol>
               <span class="name flex">[[package.title]]</span>
-            </div>
+            </a>
             <div id="element-header">
               <span class="version">[[metadata.version]]</span>
               <h2 id="element-title">[[element]]</h2>
@@ -45,12 +45,12 @@
               </div>
             </div>
 
-            <iron-selector id="nav" class="nav" attr-for-selected="name" selected="{{view}}">
-              <paper-item name="docs"><iron-icon icon="description"></iron-icon> <span>Docs</span></paper-item>
+            <nav id="nav" class="nav" attr-for-selected="name" selected="{{view}}">
+              <a is="app-link" class="item" href="[[_link(active,'docs')]]" active$="[[_isEqual(view,'docs')]]"><iron-icon icon="description"></iron-icon> <span>Docs</span></a>
               <template is="dom-repeat" items="[[docDemos]]">
-                <paper-item name="[[_demoView(item.path)]]"><iron-icon icon="visibility"></iron-icon> <span>[[_demoName(item.desc)]]</span></paper-item>
+                <a is="app-link" class="item" href="[[_demoLink(active,item.path)]]" active$="[[_demoActive(item.path,view)]]"><iron-icon icon="visibility"></iron-icon> <span>[[_demoName(item.desc)]]</span></a>
               </template>
-            </iron-selector>
+            </nav>
 
             <div class="nav" id="cart-add">
               <paper-item on-tap="toggleCart"><cart-item-icon id="cartIcon" element="[[element]]"></cart-item-icon></paper-item>
@@ -59,31 +59,31 @@
             <section hidden$="[[_oneOrFewer(docElements)]]" class="shrinkable">
               <h4>Bundled Elements</h4>
 
-              <iron-selector id="elnav" class="nav" attr-for-selected="name" selected="{{active}}">
+              <nav id="elnav" class="nav">
                 <template is="dom-repeat" items="[[docElements]]">
-                  <paper-item name="[[item.is]]">[[item.is]]</paper-item>
+                  <a is="app-link" class="item" href$="[[_link(item.is,view)]]" active$="[[_isEqual(item.is,active)]]">[[item.is]]</a>
                 </template>
-              </iron-selector>
+              </nav>
             </section>
 
             <section class="shrinkable" hidden$="[[_oneOrFewer(docBehaviors)]]">
               <h4>Bundled Behaviors</h4>
 
-              <iron-selector id="elnav" class="nav" attr-for-selected="name" selected="{{active}}">
+              <nav id="elnav" class="nav" attr-for-selected="name" selected="{{active}}">
                 <template is="dom-repeat" items="[[docBehaviors]]">
                   <paper-item name="[[item.is]]">[[item.is]]</paper-item>
                 </template>
-              </iron-selector>
+              </nav>
             </section>
 
-            <section id="all-elements" class="flex nav vertical layout shrinkable">
+            <!--<section id="all-elements" class="flex nav vertical layout shrinkable">
               <h4>All <span>[[package.title]]</span></h4>
               <iron-selector class="flex nav" attr-for-selected="name" selected="{{element}}">
                 <template is="dom-repeat" id="all" items="[[elements]]" filter="listFilter">
                   <paper-item name$="[[item.name]]">[[item.name]]</paper-item>
                 </template>
               </iron-selector>
-            </section>
+            </section>-->
           </div>
         </app-sidebar>
         <section main class="fit">
@@ -101,7 +101,7 @@
     is: 'page-element',
     enableCustomStyleProperties: true,
     properties: {
-      element: {type: String, notify: true, observer: '_elementChanged'},
+      element: {type: String, notify: true},
       view: {type: String, notify: true, value: 'docs'},
       active: {type: String, value: ''},
       docElements: Array,
@@ -114,7 +114,7 @@
       q: String
     },
     observers: [
-      'updateURL(view,active)',
+      'updateURL(active,view)',
       'updateMeta(element,active)',
       'analyze(importPath)',
       'search(q)'
@@ -125,21 +125,34 @@
     analyze: function() {
       this.$.analyzer.analyze();
     },
-    updateURL: function(view,active) {
+    _link: function(active,view) {
+      return this.getURL(active,view,true);
+    },
+    _demoLink: function(active,path) {
+      return this.getURL(active,'demo:' + path,true);
+    },
+    _demoActive: function(path) {
+      return this.view === 'demo:' + path;
+    },
+    getURL: function(active,view,force) {
       var url = "/elements/" + this.element;
 
       var qs = [];
-      if (this.view && this.view.length && this.view !== 'docs') qs.push('view=' + this.view);
-      if (this.active && this.active.length && this.active !== this.element) qs.push('active=' + this.active);
+      if (force || (view && view.length && view !== 'docs')) qs.push('view=' + view);
+      if (force || (active && active.length && active !== this.element)) qs.push('active=' + active);
       if (qs.length) url += "?" + qs.join("&");
 
+      return url;
+    },
+    updateURL: function(active,view) {
+      var url = this.getURL(active,view);
       if (this.router) this.router.go(url, {replace: true});
     },
     updateMeta: function(element,active) {
       this.fire('page-meta', {title: (this.active && this.active.length) ? this.active : this.element});
     },
-    navToPackage: function() {
-      this.router.go("/browse?package=" + this.package.name);
+    _packageLink: function() {
+      return "/browse?package=" + this.package.name;
     },
     navToElement: function(e) {
       this.router.go("/elements/" + e.currentTarget.getAttribute('name'));
@@ -174,11 +187,11 @@
     listFilter: function(el) {
       return el.package === this.package.name;
     },
-    _demoView: function(path) {
-      return "demo:" + path;
-    },
     _demoName: function(name) {
       return name === 'demo' ? 'Demo' : name;
+    },
+    _isEqual: function(a,b) {
+      return a === b;
     }
   });
 </script>

--- a/app/elements/pages/page-packages.html
+++ b/app/elements/pages/page-packages.html
@@ -21,7 +21,7 @@
       <div class="content fit">
         <div class="packages layout horizontal wrap">
           <template is="dom-repeat" items="[[packages]]">
-            <package-tile class="flex-none" name$="[[item.name]]" on-tap="select"></package-tile>
+            <a href$="[[_packageLink(item.name)]]" is="app-link" class="flex-none"><package-tile name$="[[item.name]]"></package-tile></a>
           </template>
         </div>
 
@@ -29,9 +29,9 @@
           <h3>Element Guides</h3>
           <div id="guide-list" class="horizontal layout wrap">
             <template is="dom-repeat" items="[[guides]]">
-              <guide-card guide="[[item.name]]" on-tap="guideSelect"></guide-card>
+              <a href$="[[_link('guides',item.name)]]" is="app-link"><guide-card guide="[[item.name]]"></guide-card></a>
             </template>
-            <div id="coming-soon">More guides coming soon, stay tuned!</div>
+            <div id="coming-soon">More guides coming soon, stay tuned!</div>  
           </div>
         </div>
       </div>
@@ -58,8 +58,11 @@
         this.router.go('/browse?q=' + (q || this.q));
       }
     },
-    select: function(e) {
-      this.router.go('/browse?package=' + e.currentTarget.getAttribute('name'));
+    _link: function() {
+      return "/" + Array.prototype.slice.call(arguments).join("/");
+    },
+    _packageLink: function(name) {
+      return "/browse?package=" + name;
     },
     guideSelect: function(e) {
       this.router.go('/guides/' + e.currentTarget.guide);


### PR DESCRIPTION
This PR linkifies the catalog such that the vast majority of navigation happens by normal `<a>` tags with special handling for ctrl/meta+click to open in a new window. Should resolve #91