### PR TITLE
Prevent extra comma in tag list

### DIFF
--- a/app/elements/element-table/element-table.html
+++ b/app/elements/element-table/element-table.html
@@ -119,8 +119,9 @@
             <td class="name" width="100">[[item.name]]</td>
             <td class="description relative">[[item.description]]</td>
             <td class="tags">
-              <template is="dom-repeat" items="[[item.tags]]">
-                <tag-link name="[[item]]" on-tap="tagTapped"></tag-link><span>,</span>
+              <template is="dom-repeat" items="[[item.tags]]" as="tag">
+                <tag-link name="[[tag]]" on-tap="tagTapped"></tag-link><span
+                  hidden$="[[_isLastItem(index, item.tags.length)]]">,</span>
               </template>
             </td>
             <td class="actions">
@@ -166,6 +167,9 @@ Polymer({
   },
   _elementLink: function(name) {
     return "/elements/" + name;
+  },
+  _isLastItem: function(index, length) {
+    return (index === length - 1);
   }
 });
 </script>


### PR DESCRIPTION
I know it's stupid but that has been bothering me whenever I looked at the catalog...

Before:
![comma_before](https://cloud.githubusercontent.com/assets/809528/8181786/4fe75176-1429-11e5-892f-2f7cd885f3c9.png)

After:
![comma_after](https://cloud.githubusercontent.com/assets/809528/8181788/53ded204-1429-11e5-9a4f-e7b0fafb837e.png)