### PR TITLE
Port Iron icons guide

### DIFF
--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -1,0 +1,305 @@
+---
+layout: default
+type: elements
+shortname: Elements
+title: Using core icons
+subtitle: Guide
+---
+
+<link rel="import" href="../../components/google-youtube/google-youtube.html">
+
+{% include toc.html %}
+
+{{site.project_title}}'s Core Elements provide utility components
+for working with individual icons and icon sets.
+
+It includes a standard collection of SVG icons (styleable using CSS) as well as elements to
+create your own icon sets using either SVG or bitmap icons.
+
+## Installation
+
+This article describes the usage of four components: `core-icon`,
+`core-icons`, `core-iconset` and `core-iconset-svg`.
+You can install them using Bower:
+
+    bower install Polymer/core-icon
+    bower install Polymer/core-icons
+    bower install Polymer/core-iconset
+    bower install Polymer/core-iconset-svg
+
+The rest of this article assumes the components are
+installed in the `bower_components` directory.
+
+## Basic usage: core-icon
+
+<div class="yt-embed">
+  <google-youtube
+    videoid="jrt7sMq9lO0"
+    thumbnail="/images/polycasts/PC001.jpg"
+    autoplay="0"
+    rel="0"
+    fluid>
+  </google-youtube>
+</div>
+
+The simplest way of using {{site.project_title}} icons is the `core-icon` element.
+To use it, import *core-icon.html* and declare an icon in your html:
+
+    <link rel="import" href="/bower_components/core-icon/core-icon.html">
+
+    <core-icon src="//www.polymer-project.org/images/icons/android.svg"></core-icon>
+
+Produces: <core-icon src="/images/icons/android.svg"></core-icon>
+
+The source image is scaled to fit the icon size, which defaults to 24px square, and is used as the icon element’s background.
+
+You can set the size of the icon using CSS.
+
+    <core-icon src="/images/icons/android.svg" style="width: 24px; height: 24px;"></core-icon>
+    <core-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></core-icon>
+    <core-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></core-icon>
+
+Produces: <core-icon src="/images/icons/android.svg" style="width: 24px; height: 24px;"></core-icon>
+<core-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></core-icon>
+<core-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></core-icon>
+
+**Note:** In {{site.project_title}} 0.3.4 and earlier, `core-icon` included a
+`size` attribute and didn't support sizing using CSS.
+{: .alert .alert-info }
+
+The `src` attribute works well when you want to use a single icon. However, most of the time you need more than one, so {{site.project_title}} makes it easy to work with *icon sets*.
+
+
+## Using {{site.project_title}}'s built-in icon sets
+
+If you import `core-icons`, you get access to
+a whole range of predefined icon sets. To use an icon from an icon set, use the `icon` attribute instead of `src`:
+
+    <!-- core-icons loads the default icon set and the core-icon element -->
+    <link rel="import" href="/bower_components/core-icons/core-icons.html">
+
+    <core-icon icon="polymer"></core-icon>
+
+This loads the *polymer* icon from the default iconset: <core-icon icon="polymer"></core-icon>
+
+You can find more interesting icon sets in the `core-icons` directory.
+To use an icon from one of these icon sets, first import the icon set.
+Specify the icon as <em>iconset-name</em><b>&#8239;:&#8239;</b><em>icon-name</em>.
+
+For example:
+
+    <!-- load the social icon set and core-icon element -->
+    <link rel="import" href="/bower_components/core-icons/social-icons.html">
+
+    <core-icon icon="social:cake"></core-icon>
+
+This displays the *cake* icon from the *social* iconset: <core-icon icon="social:cake"></core-icon>
+
+You can browse available icon sets on the
+[core-icons demo page](../../components/core-icons/demo.html).
+
+## Styling icons with CSS {#styling-with-css}
+
+Because icons in {{site.project_title}} iconsets are SVG-based, you can control their appearance
+with CSS. In addition to setting standard CSS properties like sizes and background colors,
+you can set SVG-specific CSS properties like `fill`, `stroke` and `stroke-width` for your icons.
+
+By default, icons use `fill: currentcolor`, so they match the current text color.
+The easiest way to override the icon color is to set the `color` property. (You
+can also set the `fill` property directly, but it requires a more specific CSS selector.)
+
+    <style>
+      core-icon[icon="android"] {
+        color: #a4c639;
+        width: 32px;
+        height: 32px;
+      }
+    </style>
+    <core-icon icon="android"></core-icon>
+
+<style>
+  core-icon[icon="android"] {
+    fill: #9aed00;
+    width: 32px;
+    height: 32px;
+  }
+</style>
+Produces: <core-icon icon="android"></core-icon>
+
+## Creating custom icon sets {#roll-your-own}
+
+<div class="yt-embed">
+  <google-youtube
+    videoid="xfiOJP8vuX4"
+    thumbnail="/images/polycasts/PC002.jpg"
+    autoplay="0"
+    rel="0"
+    fluid>
+  </google-youtube>
+</div>
+
+The styling possibilities become even more exciting when you want to make
+your own icon sets. To create a custom icon set with SVG, import and declare
+`core-iconset-svg` in your html. Because SVG is just markup, you can put your
+SVG icons inside the `core-iconset-svg` element as its children.
+
+    <link rel="import" href="../bower_components/core-iconset-svg/core-iconset-svg.html">
+    <core-iconset-svg id="custom-icons" iconSize="50">
+      <svg>
+        <defs>
+          <g id="fancy-circles">
+            <circle cx="25" cy="25" r="18" />
+            <circle cx="12" cy="12" r="10" />
+            <circle cx="35" cy="40" r="6" />
+          </g>
+        </defs>
+      </svg>
+    </core-iconset-svg>
+
+This defines a new iconset called `custom-icons` with a single icon, `fancy-circles`.
+
+Because the icons are defined as SVG, you can style them with CSS. Make
+the fancy circles even more fancy by adding some color:
+
+    <style>
+      core-icon circle {
+        fill: #0b50bf;
+      }
+      core-icon circle:first-child {
+        fill: #66bbff;
+      }
+      core-icon circle:last-child {
+        fill: #0083ff;
+      }
+    </style>
+
+Now you can display the icon with `core-icon` using the same
+<em>iconset-name</em><b>&#8239;:&#8239;</b><em>icon-name</em>
+format used for built-in icon sets. For example, to display the icon
+defined above use `custom-icons:fancy-circles` as the `icon` attribute.
+
+    <core-icon icon="custom-icons:fancy-circles" size="30"></core-icon>
+
+<style>
+  core-icon circle {
+    fill: #0b50bf;
+  }
+  core-icon circle:first-child {
+    fill: #66bbff;
+  }
+  core-icon circle:last-child {
+    fill: #0083ff;
+  }
+</style>
+<core-iconset-svg id="custom-icons" iconSize="50">
+  <svg>
+    <defs>
+      <g id="fancy-circles">
+        <circle cx="25" cy="25" r="18" />
+        <circle cx="12" cy="12" r="10" />
+        <circle cx="35" cy="40" r="6" />
+      </g>
+    </defs>
+  </svg>
+</core-iconset-svg>
+Tadaa! Here's your brand new icon: <core-icon icon="custom-icons:fancy-circles" size="30"></core-icon>
+
+If you prefer to work with more traditional bitmap graphics like *jpg* or *png*,
+there is also an element for that: `core-iconset`.
+
+For example, if you have a *png* file containing icons:
+
+<a href="../../components/core-iconset/my-icons.png" target="_blank">
+  <img src="../../components/core-iconset/my-icons.png">
+</a>
+
+You can set the `src` attribute of `core-iconset` to point to this file.
+Icons are expected to be square and of the size specified
+by the `iconSize` property. If the icons are arranged over multiple rows, use the `width`
+attribute to specify the width of the image file. List the name of each icon in the `icons` attribute, in the same order as they appear
+in the image file.
+
+    <core-iconset id="custom-icons-png" src="/components/core-iconset/my-icons.png" width="96" iconSize="24"
+      icons="location place starta stopb bus car train walk">
+    </core-iconset>
+
+Now you can use the icons in your custom set just like the built-in icons.
+
+    <core-icon icon="custom-icons-png:place"></core-icon>
+
+<core-iconset id="custom-icons-png" src="../../components/core-iconset/my-icons.png" width="96" iconSize="24"
+  icons="location place starta stopb bus car train walk">
+</core-iconset>
+Produces: <core-icon icon="custom-icons-png:place"></core-icon>
+
+## Using icons with other elements {#icons-in-other-core-components}
+
+You can use icons on their own, but also use them with other elements, such as buttons. You can use the built-in
+and custom icon sets with any `core-` or `paper-` element that has an `icon` attribute. Remember to include the
+appropriate icon set before referring to an icon, otherwise the icon will not render.
+
+The following examples use `core-icon-button`, `core-menu-button` and `core-item` with
+icons from the *default* and *av* icon sets. (The required imports for the elements and icon sets
+are omitted here for brevity.)
+
+    <core-icon-button icon="av:play-arrow"></core-icon-button>
+
+    <core-menu-button icon="menu">
+      <core-item icon="settings" label="Settings"></core-item>
+    </core-menu-button>
+
+Produces: <core-icon-button icon="av:play-arrow"></core-icon-button>
+<core-menu-button icon="menu">
+  <core-item icon="settings" label="Settings"></core-item>
+</core-menu-button>
+
+There are two ways to style the icons inside another element. Since `color` is an
+inherited property, you can set `color` on the parent element:
+
+    <style>
+      core-icon-button.green {
+        color: lightgreen;
+      }
+    </style>
+    <core-icon-button class="green" icon="av:play-arrow"></core-icon-button>
+
+<style>
+  core-icon-button.green {
+    color: lightgreen;
+  }
+</style>
+Produces: <core-icon-button class="green" icon="av:play-arrow"></core-icon-button>
+
+If you need more control, you can use the `::shadow` pseudo-element or the `/deep/`
+combinator to style the icon directly.
+
+    <style shim-shadowdom>
+      core-icon-button.outline /deep/ core-icon {
+        fill: red;
+        stroke: black;
+        stroke-width: 1;
+      }
+    </style>
+    <core-icon-button class="outline" icon="av:stop"></core-icon-button>
+
+<style shim-shadowdom>
+  core-icon-button.outline /deep/ core-icon {
+    fill: red;
+    stroke: black;
+    stroke-width: 1;
+  }
+</style>
+Produces: <core-icon-button class="outline" icon="av:stop"></core-icon-button>
+
+## Summary
+
+You just learned how to import {{site.project_title}}'s ready-made icon sets,
+display an icon using the `core-icon` element and style it with CSS. You also learned
+how to create your own icon set using SVG or bitmap images and how to use icons
+from other elements that support this feature.
+
+
+
+
+
+

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -24,15 +24,6 @@ updated: 2015-07-17
 
 ## Introduction
 
-
-
-<google-youtube
-  video-id="6kkNgVG6LuI"
-  autoplay="0"
-  rel="0"
-  fluid>
-</google-youtube>
-
 In this guide we will teach you how to display icons and how to use the 
 Polymer team's collection of icons in your project.
 
@@ -207,5 +198,17 @@ For example, to create a `paper-button` element with an icon:
 
 Produces:
 
-<paper-icon-button style="color: red;" icon="delete"></paper-icon-button>
+<paper-icon-button icon="favorite"></paper-icon-button>
+
+## Migrating from Polymer 0.5 (`core-icons`) to Polymer 1.0 (`iron-icons`)
+
+Check out Rob Dodson's Polycast below for more information on migrating
+from `core-icons` to `iron-icons`.
+
+<google-youtube
+  video-id="6kkNgVG6LuI"
+  autoplay="0"
+  rel="0"
+  fluid>
+</google-youtube>
 

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -14,12 +14,17 @@ updated: 2015-07-17
 [//]: # (get SVG icon set example working)
 [//]: # (use for displaying icons https://elements.polymer-project.org/elements/iron-icons?view=demo:demo/index.html)
 [//]: # (during review, ask about using multiple icon sets, specifying each with namespace syntax)
-[//]: # (instead of trying to display inside of document, create working
-         examples with full index.html)
+[//]: # (instead of trying to display inside of document, create working examples with full index.html)
+[//]: # (how to style icons embedded in other elements?)
+[//]: # (delete video if it mentions iron-iconset*)
+[//]: # (color not inheriting on paper-icon-button)
+
 
 <link rel="import" href="/bower_components/google-youtube/google-youtube.html">
 
 ## Introduction
+
+
 
 <google-youtube
   video-id="6kkNgVG6LuI"

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -27,6 +27,12 @@ updated: 2015-07-17
 In this guide we will teach you how to display icons and how to use the 
 Polymer team's collection of icons in your project.
 
+We discuss two elements:
+
+* `iron-icon`, for displaying and styling an icon
+* `iron-icons`, for using the Polymer team's collection of icons
+  in your project
+
 ## Installation
 
 Install the icon elements with Bower. We'll assume that your project can access 
@@ -68,6 +74,30 @@ Produces:
 <iron-icon src="/images/polymer.svg" style="width: 24px; height: 24px;"></iron-icon>
 <iron-icon src="/images/polymer.svg" style="width: 32px; height: 32px;"></iron-icon>
 <iron-icon src="/images/polymer.svg" style="width: 48px; height: 48px;"></iron-icon>
+
+### Globally styling width and height
+
+To create style rules that affect the size of all icons, create a theme file
+and use the `--iron-icon-width` and `iron-icon-height` mixins.
+
+```html
+<!-- custom-icon.html -->
+<style is="custom-icon">
+  iron-icon {
+    --iron-icon-width: 100px;
+    --iron-icon-height: 100px;
+  }
+</style>
+```
+
+Import the theme file into your page and style the icons with your custom class:
+
+```html
+   ...
+   <link rel="import" href="custom-icon.html">
+   ...
+   <iron-icon class="custom-icon" icon="accessibility"></iron-icon>
+```
 
 ## Using the Polymer team's icon collection, `iron-icons`
 
@@ -193,8 +223,7 @@ that has an `icon` attribute.
 
 For example, to create a `paper-button` element with an icon:
 
-    <paper-icon-button style="color: red;" 
-    icon="delete"></paper-icon-button>
+    <paper-icon-button icon="favorite"></paper-icon-button>
 
 Produces:
 

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -50,7 +50,9 @@ bower install PolymerElements/iron-iconset-svg
 
 ## Using `iron-icon` to display an icon
 
-Import `iron-icon` to display a single icon.
+To display an icon, import `iron-icon` and specify the source image using
+either the `src` attribute if the image is not part of an icon set,
+or the `icon` attribute if it is.
 
     ...
     <link rel="import" href="/bower_components/iron-icon/iron-icon.html">
@@ -64,7 +66,6 @@ Produces:
 
 The source image is set as the icon's background and is scaled to fit the icon 
 size. It can be bitmap or SVG. `iron-icon` expects the source image to be square.
-
 The default icon size is 24 pixels by 24 pixels. Use CSS to set the icon size.
 
     ...
@@ -79,13 +80,15 @@ Produces:
 <iron-icon src="/images/polymer.svg" style="width: 32px; height: 32px;"></iron-icon>
 <iron-icon src="/images/polymer.svg" style="width: 48px; height: 48px;"></iron-icon>
 
-## Using `iron-icons` to use the Polymer team's icon set
+## Using `iron-icons` to use the Polymer team's icon collection
 
 The Polymer team has created a large collection of free, SVG icons that 
 you can use in your own project. These icons are distributed as an element
-called `iron-icons`.
+called `iron-icons`. Think of `iron-icons` as a collection of icon sets
+(more on icon sets below).
 
-Import the `iron-icons` element into your project:
+To use one of the Polymer team's icons, import the `iron-icons` element 
+into your project and reference the icon via the `icon` attribute:
 
     ...
     <!-- iron-icons loads the default icon set and the iron-icon element -->
@@ -105,27 +108,31 @@ of an icon set.
 
 ### Browsing the `iron-icons` catalog
 
-`iron-icons` contains hundreds of icons, grouped thematically. Below
-is a current list of each of the icon set. Each link takes you to 
-the source code definition of each icon set. Look at the `id` attribute
-of each `g` element to get a general idea of the icons available in that set.
-(Note: there's an outstanding bug on the `iron-icons` demo, which is why
-we are providing this convoluted method for browsing icons)
+`iron-icons` contains hundreds of icons, grouped into the following
+icon sets: 
 
-* [General](https://github.com/PolymerElements/iron-icons/blob/master/image-icons.html)
-* [AV (Audio-Visual)](https://github.com/PolymerElements/iron-icons/blob/master/av-icons.html)
-* [Communication](https://github.com/PolymerElements/iron-icons/blob/master/communication-icons.html)
-* [Device](https://github.com/PolymerElements/iron-icons/blob/master/device-icons.html)
-* [Editor](https://github.com/PolymerElements/iron-icons/blob/master/editor-icons.html)
-* [Hardware](https://github.com/PolymerElements/iron-icons/blob/master/hardware-icons.html)
-* [Images](https://github.com/PolymerElements/iron-icons/blob/master/image-icons.html)
-* [Maps](https://github.com/PolymerElements/iron-icons/blob/master/maps-icons.html)
-* [Notification](https://github.com/PolymerElements/iron-icons/blob/master/notification-icons.html)
-* [Social](https://github.com/PolymerElements/iron-icons/blob/master/social-icons.html)
-* [Update](https://github.com/PolymerElements/iron-icons/blob/master/update-icons.sh)
+* Icon (see note at end of this section)
+* Audio Visual
+* Communication
+* Device
+* Editor
+* Hardware
+* Images
+* Maps
+* Notification
+* Social
+* Update
+
+View all of the icons at the link below.
+
+https://elements.polymer-project.org/elements/iron-icons?view=demo:demo/index.html
 
 To use an icon from one of these groups, import the icon set and then reference
-the icon as `{icon set}:{icon name}`. The example below displays the `cake` icon
+the icon using the following syntax:
+
+    <icon set>:<icon name>
+
+The example below displays the `cake` icon
 from the `social` icon set.
 
     ...

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -1,9 +1,9 @@
 ---
-layout: default
-type: elements
-shortname: Elements
-title: Using core icons
-subtitle: Guide
+title: Using iron-icons
+summary: "How to use the Polymer team's standard icons and create your own custom icons."
+tags: ['icons','intermediate']
+elements: ['iron-icon','iron-icons', 'iron-iconset', 'iron-iconset-svg']
+updated: 2015-07-17
 ---
 
 <link rel="import" href="../../components/google-youtube/google-youtube.html">

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -6,6 +6,13 @@ elements: ['iron-icon','iron-icons', 'iron-iconset', 'iron-iconset-svg']
 updated: 2015-07-17
 ---
 
+[//]: # (align docs with videos)
+[//]: # (figure out how to display iron-icons, provide a gist?)
+[//]: # (delete core-iconset video after aligning with docs)
+[//]: # (are ::shadow and /deep/ still supported?)
+[//]: # (load dependenices in right order https://github.com/PolymerElements/iron-icon/issues/19)
+
+
 <link rel="import" href="/bower_components/google-youtube/google-youtube.html">
 
 ## Introduction
@@ -17,15 +24,13 @@ updated: 2015-07-17
   fluid>
 </google-youtube>
 
+In this guide we will teach you how to use four Iron elements that make it 
+easier to use icons:
 
-The Iron package contains four elements for working with icons:
-
-* `iron-icon`, for displaying a single icon
-* `iron-icons`, for using the Polymer team's collection of common icons in your own project
+* `iron-icon`, for displaying and styling a single icon
+* `iron-icons`, for using the Polymer team's collection of common icons 
 * `iron-iconset`, for creating your own icon set
-* `iron-iconset-svg`, for styling your SVG icons
-
-In this guide we will teach you how to use each of these elements.
+* `iron-iconset-svg`, for styling SVG icons
 
 ## Installation
 
@@ -39,78 +44,93 @@ bower install Polymer/iron-iconset
 bower install Polymer/iron-iconset-svg 
 ```
 
-## Using the Polymer team's built-in icons
-
-You can use the icons that you see on this website in your own project. Let's
-get started by installing the following two elements:
-
-    bower install Polymer/iron-icon
-    bower install Polymer/iron-icons
-
-The Polymer team's collection of icons ("icon set") is located in the `iron-icons`
-element. To display a single icon you will use `iron-icon`.
-
-## Creating your own icon set
-
 ## Using `iron-icon` to display an icon
 
+Import `iron-icon` to display a single icon.
 
-
+    ...
     <link rel="import" href="/bower_components/iron-icon/iron-icon.html">
+    ...
+    <iron-icon src="/images/polymer.svg"></iron-icon>
+    ...
 
-    <iron-icon src="//www.polymer-project.org/images/icons/android.svg"></iron-icon>
+Produces: 
 
-Produces: <iron-icon icon="android"></iron-icon>
+<iron-icon src="/images/polymer.svg"></iron-icon>
 
-The source image is scaled to fit the icon size, which defaults to 24px square, and is used as the icon element’s background.
+The source image is set as the icon's background and is scaled to fit the icon 
+size. It can be bitmap or SVG. `iron-icon` expects the source image to be square.
 
-You can set the size of the icon using CSS.
+The default icon size is 24 pixels by 24 pixels. Use CSS to set the icon size.
 
-    <iron-icon src="/images/icons/android.svg" style="width: 24px; height: 24px;"></iron-icon>
-    <iron-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></iron-icon>
-    <iron-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></iron-icon>
+    ...
+    <iron-icon src="/images/polymer.svg" style="width: 24px; height: 24px;"></iron-icon>
+    <iron-icon src="/images/polymer.svg" style="width: 32px; height: 32px;"></iron-icon>
+    <iron-icon src="/images/polymer.svg" style="width: 48px; height: 48px;"></iron-icon>
+    ...
 
-Produces: <iron-icon src="/images/icons/android.svg" style="width: 24px; height: 24px;"></iron-icon>
-<iron-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></iron-icon>
-<iron-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></iron-icon>
+Produces: 
 
-**Note:** In Polymer 0.3.4 and earlier, `iron-icon` included a
-`size` attribute and didn't support sizing using CSS.
-{: .alert .alert-info }
+<iron-icon src="/images/polymer.svg" style="width: 24px; height: 24px;"></iron-icon>
+<iron-icon src="/images/polymer.svg" style="width: 32px; height: 32px;"></iron-icon>
+<iron-icon src="/images/polymer.svg" style="width: 48px; height: 48px;"></iron-icon>
 
-The `src` attribute works well when you want to use a single icon. However, most of the time you need more than one, so Polymer makes it easy to work with *icon sets*.
+## Using `iron-icons` to use the Polymer team's icon set
 
-[//]: # (To-Do: Merge with section above?)
+The Polymer team has created a large collection of free, SVG icons that 
+you can use in your own project. These icons are distributed as an element
+called `iron-icons`.
 
-## Using `iron-icons` to use the Polymer team's icon set in your project
+Import the `iron-icons` element into your project:
 
-If you import `iron-icons`, you get access to
-a whole range of predefined icon sets. To use an icon from an icon set, use the `icon` attribute instead of `src`:
-
+    ...
     <!-- iron-icons loads the default icon set and the iron-icon element -->
     <link rel="import" href="/bower_components/iron-icons/iron-icons.html">
+    ...
+    <iron-icon icon="refresh"></iron-icon>
+    ...
 
-    <iron-icon icon="polymer"></iron-icon>
 
-This loads the *polymer* icon from the default iconset: <iron-icon icon="polymer"></iron-icon>
+Produces:
 
-You can find more interesting icon sets in the `iron-icons` directory.
-To use an icon from one of these icon sets, first import the icon set.
-Specify the icon as <em>iconset-name</em><b>&#8239;:&#8239;</b><em>icon-name</em>.
+<iron-icon icon="refresh"></iron-icon>
 
-For example:
+Note that you reference the image source via the `icon` attribute, not
+the `src` attribute, as is the case when you using an image that is not part
+of an icon set.
 
-    <!-- load the social icon set and iron-icon element -->
+### Browsing the `iron-icons` catalog
+
+`iron-icons` contains hundreds of icons, grouped thematically. Below
+is a current list of each of the icon set. Each link takes you to 
+the source code definition of each icon set. Look at the `id` attribute
+of each `g` element to get a general idea of the icons available in that set.
+(Note: there's an outstanding bug on the `iron-icons` demo, which is why
+we are providing this convoluted method for browsing icons)
+
+* [General](https://github.com/PolymerElements/iron-icons/blob/master/image-icons.html)
+* [AV (Audio-Visual)](https://github.com/PolymerElements/iron-icons/blob/master/av-icons.html)
+* [Communication](https://github.com/PolymerElements/iron-icons/blob/master/communication-icons.html)
+* [Device](https://github.com/PolymerElements/iron-icons/blob/master/device-icons.html)
+* [Editor](https://github.com/PolymerElements/iron-icons/blob/master/editor-icons.html)
+* [Hardware](https://github.com/PolymerElements/iron-icons/blob/master/hardware-icons.html)
+* [Images](https://github.com/PolymerElements/iron-icons/blob/master/image-icons.html)
+* [Maps](https://github.com/PolymerElements/iron-icons/blob/master/maps-icons.html)
+* [Notification](https://github.com/PolymerElements/iron-icons/blob/master/notification-icons.html)
+* [Social](https://github.com/PolymerElements/iron-icons/blob/master/social-icons.html)
+* [Update](https://github.com/PolymerElements/iron-icons/blob/master/update-icons.sh)
+
+To use an icon from one of these groups, import the icon set and then reference
+the icon as `{icon set}:{icon name}`. The example below displays the `cake` icon
+from the `social` icon set.
+
+    ...
     <link rel="import" href="/bower_components/iron-icons/social-icons.html">
-
+    ...
     <iron-icon icon="social:cake"></iron-icon>
+    ...
 
-This displays the *cake* icon from the *social* iconset: <iron-icon icon="social:cake"></iron-icon>
-
-You can browse available icon sets on the
-[iron-icons demo page](../../components/iron-icons/demo.html).
-
-## Styling icons with CSS {#styling-with-css}
+## Styling icons with CSS 
 
 Because icons in Polymer iconsets are SVG-based, you can control their appearance
 with CSS. In addition to setting standard CSS properties like sizes and background colors,
@@ -136,19 +156,23 @@ can also set the `fill` property directly, but it requires a more specific CSS s
     height: 32px;
   }
 </style>
-Produces: <iron-icon icon="android"></iron-icon>
 
-## Creating custom icon sets with `iron-iconset` {#roll-your-own}
+Produces: 
 
-<div class="yt-embed">
-  <google-youtube
-    videoid="xfiOJP8vuX4"
-    thumbnail="/images/polycasts/PC002.jpg"
-    autoplay="0"
-    rel="0"
-    fluid>
-  </google-youtube>
-</div>
+<iron-icon icon="android"></iron-icon>
+
+## Creating custom icon sets with `iron-iconset` 
+
+[//]: # (delete after aligning video and docs)
+
+<google-youtube
+  video-id="xfiOJP8vuX4"
+  autoplay="0"
+  rel="0"
+  fluid>
+</google-youtube>
+
+[//]: # (does this video explain iron-iconset?)
 
 The styling possibilities become even more exciting when you want to make
 your own icon sets. To create a custom icon set with SVG, import and declare
@@ -244,7 +268,7 @@ Now you can use the icons in your custom set just like the built-in icons.
 </iron-iconset>
 Produces: <iron-icon icon="custom-icons-png:place"></iron-icon>
 
-## Using icons with other elements {#icons-in-other-core-components}
+## Using icons with other elements 
 
 You can use icons on their own, but also use them with other elements, such as buttons. You can use the built-in
 and custom icon sets with any `core-` or `paper-` element that has an `icon` attribute. Remember to include the

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -11,7 +11,7 @@ updated: 2015-07-17
 [//]: # (delete core-iconset video after aligning with docs)
 [//]: # (are ::shadow and /deep/ still supported?)
 [//]: # (load dependenices in right order https://github.com/PolymerElements/iron-icon/issues/19)
-
+[//]: # (get SVG icon set example working)
 
 <link rel="import" href="/bower_components/google-youtube/google-youtube.html">
 
@@ -132,13 +132,15 @@ from the `social` icon set.
 
 ## Styling icons with CSS 
 
-Because icons in Polymer iconsets are SVG-based, you can control their appearance
-with CSS. In addition to setting standard CSS properties like sizes and background colors,
-you can set SVG-specific CSS properties like `fill`, `stroke` and `stroke-width` for your icons.
+All of the icons in `iron-icons` are SVG-based. In addition to setting standard CSS 
+properties like sizes and background colors, you can set SVG-specific CSS properties 
+like `fill`, `stroke` and `stroke-width` for your icons.
 
 By default, icons use `fill: currentcolor`, so they match the current text color.
-The easiest way to override the icon color is to set the `color` property. (You
-can also set the `fill` property directly, but it requires a more specific CSS selector.)
+The easiest way to override the icon color is to set the `color` property. You
+can also set the `fill` property directly, but it requires a more specific CSS selector.
+
+[//]: # (code is different?)
 
     <style>
       iron-icon[icon="android"] {
@@ -161,7 +163,7 @@ Produces:
 
 <iron-icon icon="android"></iron-icon>
 
-## Creating custom icon sets with `iron-iconset` 
+## Creating custom bitmap icon sets with `iron-iconset`
 
 [//]: # (delete after aligning video and docs)
 
@@ -174,10 +176,15 @@ Produces:
 
 [//]: # (does this video explain iron-iconset?)
 
-The styling possibilities become even more exciting when you want to make
-your own icon sets. To create a custom icon set with SVG, import and declare
-`iron-iconset-svg` in your html. Because SVG is just markup, you can put your
-SVG icons inside the `iron-iconset-svg` element as its children.
+Use `iron-iconset` to create your own icon set. An icon set is a group of icons,
+distributed as a Polymer element. `iron-icons` above is an example of an icon set.
+
+## Creating SVG icon sets with `iron-iconset-svg`
+
+Use `iron-iconset-svg` to create an icon set of SVG icons.
+
+Import and declare `iron-iconset-svg` in your html and put your
+SVG icon definitions inside the `iron-iconset-svg` element as its children.
 
     <link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
     <iron-iconset-svg id="custom-icons" iconSize="50">
@@ -191,6 +198,8 @@ SVG icons inside the `iron-iconset-svg` element as its children.
         </defs>
       </svg>
     </iron-iconset-svg>
+
+[//]: # (move stuff to external file and link, so example works)
 
 This defines a new iconset called `custom-icons` with a single icon, `fancy-circles`.
 

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -33,13 +33,8 @@ updated: 2015-07-17
   fluid>
 </google-youtube>
 
-In this guide we will teach you how to use four Iron elements that make it 
-easier to use icons:
-
-* `iron-icon`, for displaying and styling a single icon
-* `iron-icons`, for using the Polymer team's collection of common icons 
-* `iron-iconset`, for creating your own icon set
-* `iron-iconset-svg`, for styling SVG icons
+In this guide we will teach you how to display icons and how to use the 
+Polymer team's collection of icons in your project.
 
 ## Installation
 
@@ -49,11 +44,9 @@ these elements from `/bower_components/`.
 ```bash
 bower install PolymerElements/iron-icon 
 bower install PolymerElements/iron-icons 
-bower install PolymerElements/iron-iconset 
-bower install PolymerElements/iron-iconset-svg 
 ```
 
-## Using `iron-icon` to display an icon
+## Displaying an icon with `iron-icon`
 
 To display an icon, import `iron-icon` and specify the source image using
 either the `src` attribute if the image is not part of an icon set,
@@ -85,11 +78,13 @@ Produces:
 <iron-icon src="/images/polymer.svg" style="width: 32px; height: 32px;"></iron-icon>
 <iron-icon src="/images/polymer.svg" style="width: 48px; height: 48px;"></iron-icon>
 
-## Using `iron-icons` to use the Polymer team's icon collection
+## Using the Polymer team's icon collection, `iron-icons`
 
 The Polymer team has created a large collection of free, SVG icons that 
 you can use in your own project. These icons are distributed as an element
 called `iron-icons`. 
+
+[View all of the icons here.](https://elements.polymer-project.org/elements/iron-icons?view=demo:demo/index.html)
 
 To use one of the Polymer team's icons, import the `iron-icons` element 
 into your project and reference the icon via the `icon` attribute:
@@ -110,12 +105,17 @@ Note that you reference the image source via the `icon` attribute, not
 the `src` attribute, as is the case when you using an image that is not part
 of an icon set.
 
-### Browsing the `iron-icons` catalog
+The default icon set is called `icons`. If you reference an icon 
+using only the icon name, `iron-icon` will search for the name within 
+the `icons` icon set. For example, the two declarations below reference the 
+same icon.
 
-`iron-icons` contains hundreds of icons, grouped into the following
-icon sets: 
+    <iron-icon icon="refresh"></iron-icon>
+    <iron-icon icon="icons:refresh"></iron-icon>
 
-* Icon (see note at end of this section)
+`iron-icons` contains many more icons, grouped into the following 
+thematic sets: 
+
 * Audio Visual
 * Communication
 * Device
@@ -127,38 +127,36 @@ icon sets:
 * Social
 * Update
 
-View all of the icons at the link below.
-
-https://elements.polymer-project.org/elements/iron-icons?view=demo:demo/index.html
-
 To use an icon from one of these groups, import the icon set and then reference
 the icon using the following syntax:
 
     <icon set>:<icon name>
 
-The example below displays the `cake` icon
-from the `social` icon set.
+[Due to an outstanding bug](https://github.com/PolymerElements/iron-icon/issues/19),
+ if you want to use any of the icons from the 
+thematic sets listed above, you need to load the `iron` dependencies in a specific
+order. The example HTML below successfuly displays the `cake` icon from
+the `social` icon set.
 
-    ...
-    <link rel="import" href="/bower_components/iron-icons/social-icons.html">
-    ...
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <link rel="import" href="bower_components/polymer/polymer.html">
+    <link rel="import" href="bower_components/iron-meta/iron-meta.html">
+    <link rel="import" href="bower_components/iron-flex-layout/iron-flex-layout.html">
+    <link rel="import" href="bower_components/iron-iconset-svg/iron-iconset-svg.html">
+    <link rel="import" href="bower_components/iron-iconset/iron-iconset.html">
+    <link rel="import" href="bower_components/iron-icons/iron-icons.html">
+    <link rel="import" href="bower_components/iron-icons/social-icons.html">
+    <link rel="import" href="bower_components/iron-icon/iron-icon.html">
+  </head>
+  <body>
     <iron-icon icon="social:cake"></iron-icon>
-    ...
-
-Produces: 
-
-<iron-icon icon="social:cake"></iron-icon>
-
-Note that the `icon` icon set is the default icon set. If you reference an icon 
-using only the icon name, `iron-icon` will search for the name within 
-the `icon` icon set. For example, the two declarations below reference the 
-same icon.
-
-    ...
-    <iron-icon icon="refresh"></iron-icon>
-    ...
-    <iron-icon icon="icon:refresh"></iron-icon>
-
+  </body>
+</html>
+```
 
 ### Styling icons with CSS 
 
@@ -172,91 +170,42 @@ color. The easiest way to override the icon color is to set the
 requires a more specific CSS selector.
 
     <style>
-      iron-icon[icon="android"] {
-        color: #a4c639;
+      iron-icon[icon="save"] {
+        color: green;
         width: 32px;
         height: 32px;
+        opacity: 0.50;
       }
     </style>
-    <iron-icon icon="android"></iron-icon>
+
+    <iron-icon icon="save"></iron-icon>
 
 <!-- fill: #9aed00; -->
 
 Produces: 
 
-<iron-icon icon="android" 
-           style="color: #a4c639;
-                  width: 32px;
-                  height: 32px"></iron-icon>
-
-## Using icons with other elements 
-
-You can use icons on their own, but also use them with other elements, such as buttons. You can use the built-in
-and custom icon sets with any `core-` or `paper-` element that has an `icon` attribute. Remember to include the
-appropriate icon set before referring to an icon, otherwise the icon will not render.
-
-The following examples use `iron-icon-button`, `core-menu-button` and `core-item` with
-icons from the *default* and *av* icon sets. (The required imports for the elements and icon sets
-are omitted here for brevity.)
-
-    <iron-icon-button icon="av:play-arrow"></iron-icon-button>
-
-    <core-menu-button icon="menu">
-      <core-item icon="settings" label="Settings"></core-item>
-    </core-menu-button>
-
-Produces: <iron-icon-button icon="av:play-arrow"></iron-icon-button>
-<core-menu-button icon="menu">
-  <core-item icon="settings" label="Settings"></core-item>
-</core-menu-button>
-
-There are two ways to style the icons inside another element. Since `color` is an
-inherited property, you can set `color` on the parent element:
-
-    <style>
-      iron-icon-button.green {
-        color: lightgreen;
-      }
-    </style>
-    <iron-icon-button class="green" icon="av:play-arrow"></iron-icon-button>
-
 <style>
-  iron-icon-button.green {
-    color: lightgreen;
+  iron-icon[icon="save"] {
+    color: green;
+    width: 32px;
+    height: 32px;
+    opacity: 0.50;
   }
 </style>
-Produces: <iron-icon-button class="green" icon="av:play-arrow"></iron-icon-button>
 
-If you need more control, you can use the `::shadow` pseudo-element or the `/deep/`
-combinator to style the icon directly.
+<iron-icon icon="save"></iron-icon>
 
-    <style shim-shadowdom>
-      iron-icon-button.outline /deep/ iron-icon {
-        fill: red;
-        stroke: black;
-        stroke-width: 1;
-      }
-    </style>
-    <iron-icon-button class="outline" icon="av:stop"></iron-icon-button>
+### Using icons with other elements 
 
-<style shim-shadowdom>
-  iron-icon-button.outline /deep/ iron-icon {
-    fill: red;
-    stroke: black;
-    stroke-width: 1;
-  }
-</style>
-Produces: <iron-icon-button class="outline" icon="av:stop"></iron-icon-button>
+You can use the icons from `iron-icons` with any Iron or Paper element
+that has an `icon` attribute.
 
-## Summary
+For example, to create a `paper-button` element with an icon:
 
-You just learned how to import Polymer's ready-made icon sets,
-display an icon using the `iron-icon` element and style it with CSS. You also learned
-how to create your own icon set using SVG or bitmap images and how to use icons
-from other elements that support this feature.
+    <paper-icon-button style="color: red;" 
+    icon="delete"></paper-icon-button>
 
+Produces:
 
-
-
-
+<paper-icon-button style="color: red;" icon="delete"></paper-icon-button>
 

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -42,10 +42,10 @@ Install the icon elements with Bower. We'll assume that your project can access
 these elements from `/bower_components/`.
 
 ```bash
-bower install Polymer/iron-icon 
-bower install Polymer/iron-icons 
-bower install Polymer/iron-iconset 
-bower install Polymer/iron-iconset-svg 
+bower install PolymerElements/iron-icon 
+bower install PolymerElements/iron-icons 
+bower install PolymerElements/iron-iconset 
+bower install PolymerElements/iron-iconset-svg 
 ```
 
 ## Using `iron-icon` to display an icon

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -1,6 +1,6 @@
 ---
 title: Using Icons
-summary: "How to use the Polymer team's standard icons, and create your own custom icons."
+summary: "How to display and style icons, and how to use the Polymer team's icon collection in your own project."
 tags: ['icons','intermediate']
 elements: ['iron-icon','iron-icons', 'iron-iconset', 'iron-iconset-svg']
 updated: 2015-07-17

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -6,8 +6,6 @@ elements: ['iron-icon','iron-icons', 'iron-iconset', 'iron-iconset-svg']
 updated: 2015-07-17
 ---
 
-[//]: # (To-Do: Check link to Google YouTube element.)
-
 <link rel="import" href="/bower_components/google-youtube/google-youtube.html">
 
 ## Introduction
@@ -61,8 +59,6 @@ element. To display a single icon you will use `iron-icon`.
     <link rel="import" href="/bower_components/iron-icon/iron-icon.html">
 
     <iron-icon src="//www.polymer-project.org/images/icons/android.svg"></iron-icon>
-
-[//]: # (how do you link to icons?)
 
 Produces: <iron-icon icon="android"></iron-icon>
 

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -6,9 +6,9 @@ elements: ['iron-icon','iron-icons', 'iron-iconset', 'iron-iconset-svg']
 updated: 2015-07-17
 ---
 
-<link rel="import" href="../../components/google-youtube/google-youtube.html">
+[//]: # (To-Do: Check link to Google YouTube element.)
 
-{% include toc.html %}
+<link rel="import" href="../../components/google-youtube/google-youtube.html">
 
 {{site.project_title}}'s Core Elements provide utility components
 for working with individual icons and icon sets.
@@ -18,19 +18,25 @@ create your own icon sets using either SVG or bitmap icons.
 
 ## Installation
 
-This article describes the usage of four components: `core-icon`,
-`core-icons`, `core-iconset` and `core-iconset-svg`.
+This article describes the usage of four components: `iron-icon`,
+`iron-icons`, `iron-iconset` and `iron-iconset-svg`.
 You can install them using Bower:
 
-    bower install Polymer/core-icon
-    bower install Polymer/core-icons
-    bower install Polymer/core-iconset
-    bower install Polymer/core-iconset-svg
+    bower install Polymer/iron-icon
+    bower install Polymer/iron-icons
+    bower install Polymer/iron-iconset
+    bower install Polymer/iron-iconset-svg
 
 The rest of this article assumes the components are
 installed in the `bower_components` directory.
 
-## Basic usage: core-icon
+## Polymer 0.5 to 1.0 migration note: core-icon* is now iron-icon*
+
+[//]: # (To-Do: Add content.)
+
+## Basic usage: iron-icon
+
+[//]: # (To-Do: Check if embed works.)
 
 <div class="yt-embed">
   <google-youtube
@@ -42,61 +48,62 @@ installed in the `bower_components` directory.
   </google-youtube>
 </div>
 
-The simplest way of using {{site.project_title}} icons is the `core-icon` element.
-To use it, import *core-icon.html* and declare an icon in your html:
+The simplest way of using {{site.project_title}} icons is the `iron-icon` element.
+To use it, import *iron-icon.html* and declare an icon in your html:
 
-    <link rel="import" href="/bower_components/core-icon/core-icon.html">
+    <link rel="import" href="/bower_components/iron-icon/iron-icon.html">
 
-    <core-icon src="//www.polymer-project.org/images/icons/android.svg"></core-icon>
+    <iron-icon src="//www.polymer-project.org/images/icons/android.svg"></iron-icon>
 
-Produces: <core-icon src="/images/icons/android.svg"></core-icon>
+Produces: <iron-icon src="/images/icons/android.svg"></iron-icon>
 
 The source image is scaled to fit the icon size, which defaults to 24px square, and is used as the icon element’s background.
 
 You can set the size of the icon using CSS.
 
-    <core-icon src="/images/icons/android.svg" style="width: 24px; height: 24px;"></core-icon>
-    <core-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></core-icon>
-    <core-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></core-icon>
+    <iron-icon src="/images/icons/android.svg" style="width: 24px; height: 24px;"></iron-icon>
+    <iron-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></iron-icon>
+    <iron-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></iron-icon>
 
-Produces: <core-icon src="/images/icons/android.svg" style="width: 24px; height: 24px;"></core-icon>
-<core-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></core-icon>
-<core-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></core-icon>
+Produces: <iron-icon src="/images/icons/android.svg" style="width: 24px; height: 24px;"></iron-icon>
+<iron-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></iron-icon>
+<iron-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></iron-icon>
 
-**Note:** In {{site.project_title}} 0.3.4 and earlier, `core-icon` included a
+**Note:** In {{site.project_title}} 0.3.4 and earlier, `iron-icon` included a
 `size` attribute and didn't support sizing using CSS.
 {: .alert .alert-info }
 
 The `src` attribute works well when you want to use a single icon. However, most of the time you need more than one, so {{site.project_title}} makes it easy to work with *icon sets*.
 
+[//]: # (To-Do: Merge with section above?)
 
 ## Using {{site.project_title}}'s built-in icon sets
 
-If you import `core-icons`, you get access to
+If you import `iron-icons`, you get access to
 a whole range of predefined icon sets. To use an icon from an icon set, use the `icon` attribute instead of `src`:
 
-    <!-- core-icons loads the default icon set and the core-icon element -->
-    <link rel="import" href="/bower_components/core-icons/core-icons.html">
+    <!-- iron-icons loads the default icon set and the iron-icon element -->
+    <link rel="import" href="/bower_components/iron-icons/iron-icons.html">
 
-    <core-icon icon="polymer"></core-icon>
+    <iron-icon icon="polymer"></iron-icon>
 
-This loads the *polymer* icon from the default iconset: <core-icon icon="polymer"></core-icon>
+This loads the *polymer* icon from the default iconset: <iron-icon icon="polymer"></iron-icon>
 
-You can find more interesting icon sets in the `core-icons` directory.
+You can find more interesting icon sets in the `iron-icons` directory.
 To use an icon from one of these icon sets, first import the icon set.
 Specify the icon as <em>iconset-name</em><b>&#8239;:&#8239;</b><em>icon-name</em>.
 
 For example:
 
-    <!-- load the social icon set and core-icon element -->
-    <link rel="import" href="/bower_components/core-icons/social-icons.html">
+    <!-- load the social icon set and iron-icon element -->
+    <link rel="import" href="/bower_components/iron-icons/social-icons.html">
 
-    <core-icon icon="social:cake"></core-icon>
+    <iron-icon icon="social:cake"></iron-icon>
 
-This displays the *cake* icon from the *social* iconset: <core-icon icon="social:cake"></core-icon>
+This displays the *cake* icon from the *social* iconset: <iron-icon icon="social:cake"></iron-icon>
 
 You can browse available icon sets on the
-[core-icons demo page](../../components/core-icons/demo.html).
+[iron-icons demo page](../../components/iron-icons/demo.html).
 
 ## Styling icons with CSS {#styling-with-css}
 
@@ -109,22 +116,22 @@ The easiest way to override the icon color is to set the `color` property. (You
 can also set the `fill` property directly, but it requires a more specific CSS selector.)
 
     <style>
-      core-icon[icon="android"] {
+      iron-icon[icon="android"] {
         color: #a4c639;
         width: 32px;
         height: 32px;
       }
     </style>
-    <core-icon icon="android"></core-icon>
+    <iron-icon icon="android"></iron-icon>
 
 <style>
-  core-icon[icon="android"] {
+  iron-icon[icon="android"] {
     fill: #9aed00;
     width: 32px;
     height: 32px;
   }
 </style>
-Produces: <core-icon icon="android"></core-icon>
+Produces: <iron-icon icon="android"></iron-icon>
 
 ## Creating custom icon sets {#roll-your-own}
 
@@ -140,11 +147,11 @@ Produces: <core-icon icon="android"></core-icon>
 
 The styling possibilities become even more exciting when you want to make
 your own icon sets. To create a custom icon set with SVG, import and declare
-`core-iconset-svg` in your html. Because SVG is just markup, you can put your
-SVG icons inside the `core-iconset-svg` element as its children.
+`iron-iconset-svg` in your html. Because SVG is just markup, you can put your
+SVG icons inside the `iron-iconset-svg` element as its children.
 
-    <link rel="import" href="../bower_components/core-iconset-svg/core-iconset-svg.html">
-    <core-iconset-svg id="custom-icons" iconSize="50">
+    <link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
+    <iron-iconset-svg id="custom-icons" iconSize="50">
       <svg>
         <defs>
           <g id="fancy-circles">
@@ -154,7 +161,7 @@ SVG icons inside the `core-iconset-svg` element as its children.
           </g>
         </defs>
       </svg>
-    </core-iconset-svg>
+    </iron-iconset-svg>
 
 This defines a new iconset called `custom-icons` with a single icon, `fancy-circles`.
 
@@ -162,36 +169,36 @@ Because the icons are defined as SVG, you can style them with CSS. Make
 the fancy circles even more fancy by adding some color:
 
     <style>
-      core-icon circle {
+      iron-icon circle {
         fill: #0b50bf;
       }
-      core-icon circle:first-child {
+      iron-icon circle:first-child {
         fill: #66bbff;
       }
-      core-icon circle:last-child {
+      iron-icon circle:last-child {
         fill: #0083ff;
       }
     </style>
 
-Now you can display the icon with `core-icon` using the same
+Now you can display the icon with `iron-icon` using the same
 <em>iconset-name</em><b>&#8239;:&#8239;</b><em>icon-name</em>
 format used for built-in icon sets. For example, to display the icon
 defined above use `custom-icons:fancy-circles` as the `icon` attribute.
 
-    <core-icon icon="custom-icons:fancy-circles" size="30"></core-icon>
+    <iron-icon icon="custom-icons:fancy-circles" size="30"></iron-icon>
 
 <style>
-  core-icon circle {
+  iron-icon circle {
     fill: #0b50bf;
   }
-  core-icon circle:first-child {
+  iron-icon circle:first-child {
     fill: #66bbff;
   }
-  core-icon circle:last-child {
+  iron-icon circle:last-child {
     fill: #0083ff;
   }
 </style>
-<core-iconset-svg id="custom-icons" iconSize="50">
+<iron-iconset-svg id="custom-icons" iconSize="50">
   <svg>
     <defs>
       <g id="fancy-circles">
@@ -201,36 +208,36 @@ defined above use `custom-icons:fancy-circles` as the `icon` attribute.
       </g>
     </defs>
   </svg>
-</core-iconset-svg>
-Tadaa! Here's your brand new icon: <core-icon icon="custom-icons:fancy-circles" size="30"></core-icon>
+</iron-iconset-svg>
+Tadaa! Here's your brand new icon: <iron-icon icon="custom-icons:fancy-circles" size="30"></iron-icon>
 
 If you prefer to work with more traditional bitmap graphics like *jpg* or *png*,
-there is also an element for that: `core-iconset`.
+there is also an element for that: `iron-iconset`.
 
 For example, if you have a *png* file containing icons:
 
-<a href="../../components/core-iconset/my-icons.png" target="_blank">
-  <img src="../../components/core-iconset/my-icons.png">
+<a href="../../components/iron-iconset/my-icons.png" target="_blank">
+  <img src="../../components/iron-iconset/my-icons.png">
 </a>
 
-You can set the `src` attribute of `core-iconset` to point to this file.
+You can set the `src` attribute of `iron-iconset` to point to this file.
 Icons are expected to be square and of the size specified
 by the `iconSize` property. If the icons are arranged over multiple rows, use the `width`
 attribute to specify the width of the image file. List the name of each icon in the `icons` attribute, in the same order as they appear
 in the image file.
 
-    <core-iconset id="custom-icons-png" src="/components/core-iconset/my-icons.png" width="96" iconSize="24"
+    <iron-iconset id="custom-icons-png" src="/components/iron-iconset/my-icons.png" width="96" iconSize="24"
       icons="location place starta stopb bus car train walk">
-    </core-iconset>
+    </iron-iconset>
 
 Now you can use the icons in your custom set just like the built-in icons.
 
-    <core-icon icon="custom-icons-png:place"></core-icon>
+    <iron-icon icon="custom-icons-png:place"></iron-icon>
 
-<core-iconset id="custom-icons-png" src="../../components/core-iconset/my-icons.png" width="96" iconSize="24"
+<iron-iconset id="custom-icons-png" src="../../components/iron-iconset/my-icons.png" width="96" iconSize="24"
   icons="location place starta stopb bus car train walk">
-</core-iconset>
-Produces: <core-icon icon="custom-icons-png:place"></core-icon>
+</iron-iconset>
+Produces: <iron-icon icon="custom-icons-png:place"></iron-icon>
 
 ## Using icons with other elements {#icons-in-other-core-components}
 
@@ -238,17 +245,17 @@ You can use icons on their own, but also use them with other elements, such as b
 and custom icon sets with any `core-` or `paper-` element that has an `icon` attribute. Remember to include the
 appropriate icon set before referring to an icon, otherwise the icon will not render.
 
-The following examples use `core-icon-button`, `core-menu-button` and `core-item` with
+The following examples use `iron-icon-button`, `core-menu-button` and `core-item` with
 icons from the *default* and *av* icon sets. (The required imports for the elements and icon sets
 are omitted here for brevity.)
 
-    <core-icon-button icon="av:play-arrow"></core-icon-button>
+    <iron-icon-button icon="av:play-arrow"></iron-icon-button>
 
     <core-menu-button icon="menu">
       <core-item icon="settings" label="Settings"></core-item>
     </core-menu-button>
 
-Produces: <core-icon-button icon="av:play-arrow"></core-icon-button>
+Produces: <iron-icon-button icon="av:play-arrow"></iron-icon-button>
 <core-menu-button icon="menu">
   <core-item icon="settings" label="Settings"></core-item>
 </core-menu-button>
@@ -257,44 +264,44 @@ There are two ways to style the icons inside another element. Since `color` is a
 inherited property, you can set `color` on the parent element:
 
     <style>
-      core-icon-button.green {
+      iron-icon-button.green {
         color: lightgreen;
       }
     </style>
-    <core-icon-button class="green" icon="av:play-arrow"></core-icon-button>
+    <iron-icon-button class="green" icon="av:play-arrow"></iron-icon-button>
 
 <style>
-  core-icon-button.green {
+  iron-icon-button.green {
     color: lightgreen;
   }
 </style>
-Produces: <core-icon-button class="green" icon="av:play-arrow"></core-icon-button>
+Produces: <iron-icon-button class="green" icon="av:play-arrow"></iron-icon-button>
 
 If you need more control, you can use the `::shadow` pseudo-element or the `/deep/`
 combinator to style the icon directly.
 
     <style shim-shadowdom>
-      core-icon-button.outline /deep/ core-icon {
+      iron-icon-button.outline /deep/ iron-icon {
         fill: red;
         stroke: black;
         stroke-width: 1;
       }
     </style>
-    <core-icon-button class="outline" icon="av:stop"></core-icon-button>
+    <iron-icon-button class="outline" icon="av:stop"></iron-icon-button>
 
 <style shim-shadowdom>
-  core-icon-button.outline /deep/ core-icon {
+  iron-icon-button.outline /deep/ iron-icon {
     fill: red;
     stroke: black;
     stroke-width: 1;
   }
 </style>
-Produces: <core-icon-button class="outline" icon="av:stop"></core-icon-button>
+Produces: <iron-icon-button class="outline" icon="av:stop"></iron-icon-button>
 
 ## Summary
 
 You just learned how to import {{site.project_title}}'s ready-made icon sets,
-display an icon using the `core-icon` element and style it with CSS. You also learned
+display an icon using the `iron-icon` element and style it with CSS. You also learned
 how to create your own icon set using SVG or bitmap images and how to use icons
 from other elements that support this feature.
 

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -84,8 +84,7 @@ Produces:
 
 The Polymer team has created a large collection of free, SVG icons that 
 you can use in your own project. These icons are distributed as an element
-called `iron-icons`. Think of `iron-icons` as a collection of icon sets
-(more on icon sets below).
+called `iron-icons`. 
 
 To use one of the Polymer team's icons, import the `iron-icons` element 
 into your project and reference the icon via the `icon` attribute:
@@ -141,17 +140,31 @@ from the `social` icon set.
     <iron-icon icon="social:cake"></iron-icon>
     ...
 
-## Styling icons with CSS 
+Produces: 
 
-All of the icons in `iron-icons` are SVG-based. In addition to setting standard CSS 
-properties like sizes and background colors, you can set SVG-specific CSS properties 
-like `fill`, `stroke` and `stroke-width` for your icons.
+<iron-icon icon="social:cake"></iron-icon>
 
-By default, icons use `fill: currentcolor`, so they match the current text color.
-The easiest way to override the icon color is to set the `color` property. You
-can also set the `fill` property directly, but it requires a more specific CSS selector.
+Note that the `icon` icon set is the default icon set. If you reference an icon 
+using only the icon name, `iron-icon` will search for the name within 
+the `icon` icon set. For example, the two declarations below reference the 
+same icon.
 
-[//]: # (code is different?)
+    ...
+    <iron-icon icon="refresh"></iron-icon>
+    ...
+    <iron-icon icon="icon:refresh"></iron-icon>
+
+
+### Styling icons with CSS 
+
+All of the icons in `iron-icons` are SVG-based. In addition to setting 
+standard CSS properties like sizes and background colors, you can set 
+SVG-specific CSS properties like `fill`, `stroke` and `stroke-width`.
+
+By default, icons use `fill: currentcolor`, so they match the current text 
+color. The easiest way to override the icon color is to set the 
+`color` property. You can also set the `fill` property directly, but it 
+requires a more specific CSS selector.
 
     <style>
       iron-icon[icon="android"] {
@@ -162,131 +175,14 @@ can also set the `fill` property directly, but it requires a more specific CSS s
     </style>
     <iron-icon icon="android"></iron-icon>
 
-<style>
-  iron-icon[icon="android"] {
-    fill: #9aed00;
-    width: 32px;
-    height: 32px;
-  }
-</style>
+<!-- fill: #9aed00; -->
 
 Produces: 
 
-<iron-icon icon="android"></iron-icon>
-
-## Creating custom bitmap icon sets with `iron-iconset`
-
-[//]: # (delete after aligning video and docs)
-
-<google-youtube
-  video-id="xfiOJP8vuX4"
-  autoplay="0"
-  rel="0"
-  fluid>
-</google-youtube>
-
-[//]: # (does this video explain iron-iconset?)
-
-Use `iron-iconset` to create your own icon set. An icon set is a group of icons,
-distributed as a Polymer element. `iron-icons` above is an example of an icon set.
-
-## Creating SVG icon sets with `iron-iconset-svg`
-
-Use `iron-iconset-svg` to create an icon set of SVG icons.
-
-Import and declare `iron-iconset-svg` in your html and put your
-SVG icon definitions inside the `iron-iconset-svg` element as its children.
-
-    <link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
-    <iron-iconset-svg id="custom-icons" iconSize="50">
-      <svg>
-        <defs>
-          <g id="fancy-circles">
-            <circle cx="25" cy="25" r="18" />
-            <circle cx="12" cy="12" r="10" />
-            <circle cx="35" cy="40" r="6" />
-          </g>
-        </defs>
-      </svg>
-    </iron-iconset-svg>
-
-[//]: # (move stuff to external file and link, so example works)
-
-This defines a new iconset called `custom-icons` with a single icon, `fancy-circles`.
-
-Because the icons are defined as SVG, you can style them with CSS. Make
-the fancy circles even more fancy by adding some color:
-
-    <style>
-      iron-icon circle {
-        fill: #0b50bf;
-      }
-      iron-icon circle:first-child {
-        fill: #66bbff;
-      }
-      iron-icon circle:last-child {
-        fill: #0083ff;
-      }
-    </style>
-
-Now you can display the icon with `iron-icon` using the same
-<em>iconset-name</em><b>&#8239;:&#8239;</b><em>icon-name</em>
-format used for built-in icon sets. For example, to display the icon
-defined above use `custom-icons:fancy-circles` as the `icon` attribute.
-
-    <iron-icon icon="custom-icons:fancy-circles" size="30"></iron-icon>
-
-<style>
-  iron-icon circle {
-    fill: #0b50bf;
-  }
-  iron-icon circle:first-child {
-    fill: #66bbff;
-  }
-  iron-icon circle:last-child {
-    fill: #0083ff;
-  }
-</style>
-<iron-iconset-svg id="custom-icons" iconSize="50">
-  <svg>
-    <defs>
-      <g id="fancy-circles">
-        <circle cx="25" cy="25" r="18" />
-        <circle cx="12" cy="12" r="10" />
-        <circle cx="35" cy="40" r="6" />
-      </g>
-    </defs>
-  </svg>
-</iron-iconset-svg>
-Tadaa! Here's your brand new icon: <iron-icon icon="custom-icons:fancy-circles" size="30"></iron-icon>
-
-If you prefer to work with more traditional bitmap graphics like *jpg* or *png*,
-there is also an element for that: `iron-iconset`.
-
-For example, if you have a *png* file containing icons:
-
-<a href="../../components/iron-iconset/my-icons.png" target="_blank">
-  <img src="../../components/iron-iconset/my-icons.png">
-</a>
-
-You can set the `src` attribute of `iron-iconset` to point to this file.
-Icons are expected to be square and of the size specified
-by the `iconSize` property. If the icons are arranged over multiple rows, use the `width`
-attribute to specify the width of the image file. List the name of each icon in the `icons` attribute, in the same order as they appear
-in the image file.
-
-    <iron-iconset id="custom-icons-png" src="/components/iron-iconset/my-icons.png" width="96" iconSize="24"
-      icons="location place starta stopb bus car train walk">
-    </iron-iconset>
-
-Now you can use the icons in your custom set just like the built-in icons.
-
-    <iron-icon icon="custom-icons-png:place"></iron-icon>
-
-<iron-iconset id="custom-icons-png" src="../../components/iron-iconset/my-icons.png" width="96" iconSize="24"
-  icons="location place starta stopb bus car train walk">
-</iron-iconset>
-Produces: <iron-icon icon="custom-icons-png:place"></iron-icon>
+<iron-icon icon="android" 
+           style="color: #a4c639;
+                  width: 32px;
+                  height: 32px"></iron-icon>
 
 ## Using icons with other elements 
 

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -1,6 +1,6 @@
 ---
-title: Using iron-icons
-summary: "How to use the Polymer team's standard icons and create your own custom icons."
+title: Using Icons
+summary: "How to use the Polymer team's standard icons, and create your own custom icons."
 tags: ['icons','intermediate']
 elements: ['iron-icon','iron-icons', 'iron-iconset', 'iron-iconset-svg']
 updated: 2015-07-17
@@ -8,54 +8,63 @@ updated: 2015-07-17
 
 [//]: # (To-Do: Check link to Google YouTube element.)
 
-<link rel="import" href="../../components/google-youtube/google-youtube.html">
+<link rel="import" href="/bower_components/google-youtube/google-youtube.html">
 
-{{site.project_title}}'s Core Elements provide utility components
-for working with individual icons and icon sets.
+## Introduction
 
-It includes a standard collection of SVG icons (styleable using CSS) as well as elements to
-create your own icon sets using either SVG or bitmap icons.
+<google-youtube
+  video-id="6kkNgVG6LuI"
+  autoplay="0"
+  rel="0"
+  fluid>
+</google-youtube>
+
+
+The Iron package contains four elements for working with icons:
+
+* `iron-icon`, for displaying a single icon
+* `iron-icons`, for using the Polymer team's collection of common icons in your own project
+* `iron-iconset`, for creating your own icon set
+* `iron-iconset-svg`, for styling your SVG icons
+
+In this guide we will teach you how to use each of these elements.
 
 ## Installation
 
-This article describes the usage of four components: `iron-icon`,
-`iron-icons`, `iron-iconset` and `iron-iconset-svg`.
-You can install them using Bower:
+Install the icon elements with Bower. We'll assume that your project can access 
+these elements from `/bower_components/`.
+
+```bash
+bower install Polymer/iron-icon 
+bower install Polymer/iron-icons 
+bower install Polymer/iron-iconset 
+bower install Polymer/iron-iconset-svg 
+```
+
+## Using the Polymer team's built-in icons
+
+You can use the icons that you see on this website in your own project. Let's
+get started by installing the following two elements:
 
     bower install Polymer/iron-icon
     bower install Polymer/iron-icons
-    bower install Polymer/iron-iconset
-    bower install Polymer/iron-iconset-svg
 
-The rest of this article assumes the components are
-installed in the `bower_components` directory.
+The Polymer team's collection of icons ("icon set") is located in the `iron-icons`
+element. To display a single icon you will use `iron-icon`.
 
-## Polymer 0.5 to 1.0 migration note: core-icon* is now iron-icon*
+## Creating your own icon set
 
-[//]: # (To-Do: Add content.)
+## Using `iron-icon` to display an icon
 
-## Basic usage: iron-icon
 
-[//]: # (To-Do: Check if embed works.)
-
-<div class="yt-embed">
-  <google-youtube
-    videoid="jrt7sMq9lO0"
-    thumbnail="/images/polycasts/PC001.jpg"
-    autoplay="0"
-    rel="0"
-    fluid>
-  </google-youtube>
-</div>
-
-The simplest way of using {{site.project_title}} icons is the `iron-icon` element.
-To use it, import *iron-icon.html* and declare an icon in your html:
 
     <link rel="import" href="/bower_components/iron-icon/iron-icon.html">
 
     <iron-icon src="//www.polymer-project.org/images/icons/android.svg"></iron-icon>
 
-Produces: <iron-icon src="/images/icons/android.svg"></iron-icon>
+[//]: # (how do you link to icons?)
+
+Produces: <iron-icon icon="android"></iron-icon>
 
 The source image is scaled to fit the icon size, which defaults to 24px square, and is used as the icon element’s background.
 
@@ -69,15 +78,15 @@ Produces: <iron-icon src="/images/icons/android.svg" style="width: 24px; height:
 <iron-icon src="/images/icons/android.svg" style="width: 32px; height: 32px;"></iron-icon>
 <iron-icon src="/images/icons/android.svg" style="width: 48px; height: 48px;"></iron-icon>
 
-**Note:** In {{site.project_title}} 0.3.4 and earlier, `iron-icon` included a
+**Note:** In Polymer 0.3.4 and earlier, `iron-icon` included a
 `size` attribute and didn't support sizing using CSS.
 {: .alert .alert-info }
 
-The `src` attribute works well when you want to use a single icon. However, most of the time you need more than one, so {{site.project_title}} makes it easy to work with *icon sets*.
+The `src` attribute works well when you want to use a single icon. However, most of the time you need more than one, so Polymer makes it easy to work with *icon sets*.
 
 [//]: # (To-Do: Merge with section above?)
 
-## Using {{site.project_title}}'s built-in icon sets
+## Using `iron-icons` to use the Polymer team's icon set in your project
 
 If you import `iron-icons`, you get access to
 a whole range of predefined icon sets. To use an icon from an icon set, use the `icon` attribute instead of `src`:
@@ -107,7 +116,7 @@ You can browse available icon sets on the
 
 ## Styling icons with CSS {#styling-with-css}
 
-Because icons in {{site.project_title}} iconsets are SVG-based, you can control their appearance
+Because icons in Polymer iconsets are SVG-based, you can control their appearance
 with CSS. In addition to setting standard CSS properties like sizes and background colors,
 you can set SVG-specific CSS properties like `fill`, `stroke` and `stroke-width` for your icons.
 
@@ -133,7 +142,7 @@ can also set the `fill` property directly, but it requires a more specific CSS s
 </style>
 Produces: <iron-icon icon="android"></iron-icon>
 
-## Creating custom icon sets {#roll-your-own}
+## Creating custom icon sets with `iron-iconset` {#roll-your-own}
 
 <div class="yt-embed">
   <google-youtube
@@ -300,7 +309,7 @@ Produces: <iron-icon-button class="outline" icon="av:stop"></iron-icon-button>
 
 ## Summary
 
-You just learned how to import {{site.project_title}}'s ready-made icon sets,
+You just learned how to import Polymer's ready-made icon sets,
 display an icon using the `iron-icon` element and style it with CSS. You also learned
 how to create your own icon set using SVG or bitmap images and how to use icons
 from other elements that support this feature.

--- a/guides/using-iron-icons.md
+++ b/guides/using-iron-icons.md
@@ -12,6 +12,10 @@ updated: 2015-07-17
 [//]: # (are ::shadow and /deep/ still supported?)
 [//]: # (load dependenices in right order https://github.com/PolymerElements/iron-icon/issues/19)
 [//]: # (get SVG icon set example working)
+[//]: # (use for displaying icons https://elements.polymer-project.org/elements/iron-icons?view=demo:demo/index.html)
+[//]: # (during review, ask about using multiple icon sets, specifying each with namespace syntax)
+[//]: # (instead of trying to display inside of document, create working
+         examples with full index.html)
 
 <link rel="import" href="/bower_components/google-youtube/google-youtube.html">
 


### PR DESCRIPTION
R (@tjsavage && (@ebidel || @robdodson))
* Ported 0.5 guide to 1.0.
* Removed sections on icon sets due to dependency loading bug. See PolymerElements/iron-icon#19.
* Added section about needing to load dependencies in specific order when using the `social`, `av`, etc. icon sets from `iron-icons` due to the same bug listed above.
* Added section on using mixins to style icons globally, in alignment with Rob's `iron-icons` Polycast.