### PR TITLE
🍕Force search cursor to end.

### DIFF
--- a/app/elements/pages/page-browse.html
+++ b/app/elements/pages/page-browse.html
@@ -238,7 +238,13 @@
       updateSearch: function() {
         var params = this._parseQueryString();
         if (params && params.q) {
-          this.async(function() { this.$.query.focus(); });
+          this.async(function() {
+            this.$.query.focus();
+
+            // make sure to force the cursor to the end of the
+            // input. Only an issue in Firefox.
+            this.$.query.setSelectionRange(params.q.length, params.q.length);
+          });
         }
       },
       updateURL: function(q,p,tag,view) {


### PR DESCRIPTION
Fixes #147


:bug: Bug

##### How to reproduce 

* visit http://elements.polymer-project.org in firefox :fire: :wolf: 
* type in top search bar "goat" :goat: 
* you should see `oatg` now in the search box on the left :crying_cat_face: 

##### What this fixes

* when you now type goat :goat: 
* the left input now says :goat: yay :hand: 

:sparkles: 