### PR TITLE
Allow third party repository locations

### DIFF
--- a/app/elements/element-action-menu/element-action-menu.html
+++ b/app/elements/element-action-menu/element-action-menu.html
@@ -34,7 +34,7 @@
     <catalog-element name="[[element]]" data="{{_element}}"></catalog-element>
     <a tabindex="0" role="button" on-tap="cartAdd"><cart-item-icon id="cartItemIcon" element="[[element]]" present-label="Remove" absent-label="Add" no-label="[[iconsOnly]]"></cart-item-icon></a>
     <a tabindex="0" role="button" on-click="navToDocs" aria-label="View Docs"><iron-icon icon="description" title="View Docs"></iron-icon><span hidden$="[[iconsOnly]]">Docs</span></a>
-    <a tabindex="0" role="button" href="[[githubLink(_element.source)]]" target="_blank" title="View Source on GitHub" aria-label="View Source on GitHub"><iron-icon icon="code"></iron-icon><span hidden$="[[iconsOnly]]">Source</span></a>
+    <a tabindex="0" role="button" href="[[repositoryLink(_element.source)]]" target="_blank" title="View Source on GitHub" aria-label="View Source on GitHub"><iron-icon icon="code"></iron-icon><span hidden$="[[iconsOnly]]">Source</span></a>
     <a tabindex="0" role="button" on-click="navToDemo" disabled$="[[!_element.demo]]" aria-label="View Demo"><iron-icon icon="visibility" title="View Demo"></iron-icon><span hidden$="[[iconsOnly]]">Demo</span></a>
   </template>
 </dom-module>
@@ -46,6 +46,9 @@ Polymer({
     element: String,
     _element: Object,
     iconsOnly: {type: Boolean, value: false, reflectToAttribute: true}
+  },
+  repositoryLink: function(source) {
+    return (source.indexOf('http') >= 0) ? source : githubLink(source);
   },
   githubLink: function(source) {
     return "https://github.com/" + source;

--- a/app/elements/element-action-menu/element-action-menu.html
+++ b/app/elements/element-action-menu/element-action-menu.html
@@ -48,9 +48,9 @@ Polymer({
     iconsOnly: {type: Boolean, value: false, reflectToAttribute: true}
   },
   repositoryLink: function(source) {
-    return (source.indexOf('http') >= 0) ? source : githubLink(source);
+    return (source.indexOf('http') >= 0) ? source : this._githubLink(source);
   },
-  githubLink: function(source) {
+  _githubLink: function(source) {
     return "https://github.com/" + source;
   },
   cartAdd: function(e) {

--- a/app/elements/element-action-menu/element-action-menu.html
+++ b/app/elements/element-action-menu/element-action-menu.html
@@ -48,7 +48,7 @@ Polymer({
     iconsOnly: {type: Boolean, value: false, reflectToAttribute: true}
   },
   repositoryLink: function(source) {
-    return (source.indexOf('http') >= 0) ? source : this._githubLink(source);
+    return (source.indexOf('http') === 0) ? source : this._githubLink(source);
   },
   _githubLink: function(source) {
     return "https://github.com/" + source;

--- a/app/elements/pages/page-element.html
+++ b/app/elements/pages/page-element.html
@@ -50,7 +50,7 @@
               <template is="dom-repeat" items="[[docDemos]]">
                 <a is="app-link" class="item" href="[[_demoLink(active,item.path)]]" active$="[[_demoActive(item.path,view)]]"><iron-icon icon="visibility"></iron-icon> <span>[[_demoName(item.desc)]]</span></a>
               </template>
-              <a class="item" href="[[_githubLink(metadata.source)]]" target="_blank"><iron-icon icon="code"></iron-icon> <span>Source</span></a>
+              <a class="item" href="[[repositoryLink(metadata.source)]]" target="_blank"><iron-icon icon="code"></iron-icon> <span>Source</span></a>
             </nav>
 
             <div class="nav" id="cart-add">
@@ -137,6 +137,9 @@
     },
     _demoActive: function(path) {
       return this.view === 'demo:' + path;
+    },
+    repositoryLink: function(source) {
+      return (source.indexOf('http') >= 0) ? source : githubLink(source);
     },
     _githubLink: function(source) {
       return 'https://github.com/' + source;

--- a/app/elements/pages/page-element.html
+++ b/app/elements/pages/page-element.html
@@ -139,7 +139,7 @@
       return this.view === 'demo:' + path;
     },
     repositoryLink: function(source) {
-      return (source.indexOf('http') >= 0) ? source : githubLink(source);
+      return (source.indexOf('http') >= 0) ? source : this._githubLink(source);
     },
     _githubLink: function(source) {
       return 'https://github.com/' + source;

--- a/app/elements/pages/page-element.html
+++ b/app/elements/pages/page-element.html
@@ -139,7 +139,7 @@
       return this.view === 'demo:' + path;
     },
     repositoryLink: function(source) {
-      return (source.indexOf('http') >= 0) ? source : this._githubLink(source);
+      return (source.indexOf('http') === 0) ? source : this._githubLink(source);
     },
     _githubLink: function(source) {
       return 'https://github.com/' + source;


### PR DESCRIPTION
Hi there,

I'm using polymer-element-catalog for generating our own project documentation, but there seems that source code's link always go to github, and we're using stash. I'd modified this file in order to allow full http links, instead of github relative repos.

I hope you like it, I think it'll help people like me to use their own repos.

Regards
