### PR TITLE
Fix demos in Material Design guide

### DIFF
--- a/guides/assets/custom-header.html
+++ b/guides/assets/custom-header.html
@@ -10,13 +10,13 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-body {
-    font-family: Roboto, 'Noto', 'Helvetica Neue', 
-                 Helvetica, Arial, sans-serif;
-}
-.paper-header {
-  padding: 25px;
-}
+    body {
+      font-family: Roboto, 'Noto', 'Helvetica Neue',
+                   Helvetica, Arial, sans-serif;
+    }
+    .paper-header {
+      padding: 25px;
+    }
   </style>
 </head>
 <body class="fullbleed vertical layout">

--- a/guides/assets/custom-header.html
+++ b/guides/assets/custom-header.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">

--- a/guides/assets/custom-header.html
+++ b/guides/assets/custom-header.html
@@ -3,7 +3,6 @@
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">
   </script>
-  <link rel="import" href="/bower_components/polymer/polymer.html">
   <link rel="import"
         href="/bower_components/paper-header-panel/paper-header-panel.html">
   <link rel="import"

--- a/guides/assets/custom-header.html
+++ b/guides/assets/custom-header.html
@@ -10,11 +10,10 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-:root {
-    --primary-font-family: Roboto, 'Noto', 'Helvetica Neue', 
-                           Helvetica, Arial, sans-serif;
+body {
+    font-family: Roboto, 'Noto', 'Helvetica Neue', 
+                 Helvetica, Arial, sans-serif;
 }
-
 .paper-header {
   padding: 25px;
 }

--- a/guides/assets/custom-header.html
+++ b/guides/assets/custom-header.html
@@ -9,7 +9,7 @@
   <link rel="import"
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
   <link rel="import"
-        href="/bower_components/font-roboto/font-roboto.html">
+        href="/bower_components/font-roboto/roboto.html">
   <style>
 :root {
     --primary-font-family: Roboto, 'Noto', 'Helvetica Neue', 

--- a/guides/assets/drawer.html
+++ b/guides/assets/drawer.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">

--- a/guides/assets/drawer.html
+++ b/guides/assets/drawer.html
@@ -17,7 +17,7 @@
   <link rel="import"
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
   <link rel="import"
-        href="/bower_components/font-roboto/font-roboto.html">
+        href="/bower_components/font-roboto/roboto.html">
   <style>
 :root { 
     --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',  

--- a/guides/assets/drawer.html
+++ b/guides/assets/drawer.html
@@ -18,9 +18,9 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-:root { 
-    --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',  
-                           Helvetica, Arial, sans-serif; 
+body { 
+    font-family: Roboto, 'Noto', 'Helvetica Neue',  
+                 Helvetica, Arial, sans-serif; 
 }
   </style>
 </head>

--- a/guides/assets/drawer.html
+++ b/guides/assets/drawer.html
@@ -3,7 +3,6 @@
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">
   </script>
-  <link rel="import" href="/bower_components/polymer/polymer.html">
   <link rel="import"
         href="/bower_components/paper-drawer-panel/paper-drawer-panel.html">
   <link rel="import"

--- a/guides/assets/drawer.html
+++ b/guides/assets/drawer.html
@@ -18,10 +18,10 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-body { 
-    font-family: Roboto, 'Noto', 'Helvetica Neue',  
-                 Helvetica, Arial, sans-serif; 
-}
+    body {
+      font-family: Roboto, 'Noto', 'Helvetica Neue',  
+                   Helvetica, Arial, sans-serif;
+    }
   </style>
 </head>
 <body class="fullbleed vertical layout">

--- a/guides/assets/header-and-toolbar.html
+++ b/guides/assets/header-and-toolbar.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">

--- a/guides/assets/header-and-toolbar.html
+++ b/guides/assets/header-and-toolbar.html
@@ -3,7 +3,6 @@
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">
   </script>
-  <link rel="import" href="/bower_components/polymer/polymer.html">
   <link rel="import"
         href="/bower_components/paper-header-panel/paper-header-panel.html">
   <link rel="import"

--- a/guides/assets/header-and-toolbar.html
+++ b/guides/assets/header-and-toolbar.html
@@ -12,10 +12,10 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-body { 
-    font-family: Roboto, 'Noto', 'Helvetica Neue',  
-                 Helvetica, Arial, sans-serif; 
-}
+    body {
+      font-family: Roboto, 'Noto', 'Helvetica Neue',  
+                   Helvetica, Arial, sans-serif;
+    }
   </style>
 </head>
 <body class="fullbleed vertical layout">

--- a/guides/assets/header-and-toolbar.html
+++ b/guides/assets/header-and-toolbar.html
@@ -11,7 +11,7 @@
   <link rel="import"
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
   <link rel="import"
-        href="/bower_components/font-roboto/font-roboto.html">
+        href="/bower_components/font-roboto/roboto.html">
   <style>
 :root { 
     --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',  

--- a/guides/assets/header-and-toolbar.html
+++ b/guides/assets/header-and-toolbar.html
@@ -12,9 +12,9 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-:root { 
-    --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',  
-                           Helvetica, Arial, sans-serif; 
+body { 
+    font-family: Roboto, 'Noto', 'Helvetica Neue',  
+                 Helvetica, Arial, sans-serif; 
 }
   </style>
 </head>

--- a/guides/assets/icons.html
+++ b/guides/assets/icons.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">

--- a/guides/assets/icons.html
+++ b/guides/assets/icons.html
@@ -3,7 +3,6 @@
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">
   </script>
-  <link rel="import" href="/bower_components/polymer/polymer.html">
   <link rel="import"
         href="/bower_components/paper-header-panel/paper-header-panel.html">
   <link rel="import"

--- a/guides/assets/icons.html
+++ b/guides/assets/icons.html
@@ -16,10 +16,10 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-body {
-    font-family: Roboto, 'Noto', 'Helvetica Neue',
-                 Helvetica, Arial, sans-serif;
-}
+    body {
+      font-family: Roboto, 'Noto', 'Helvetica Neue',
+                   Helvetica, Arial, sans-serif;
+    }
   </style>
 </head>
 <body class="fullbleed vertical layout">

--- a/guides/assets/icons.html
+++ b/guides/assets/icons.html
@@ -16,9 +16,9 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-:root {
-    --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',
-                           Helvetica, Arial, sans-serif;
+body {
+    font-family: Roboto, 'Noto', 'Helvetica Neue',
+                 Helvetica, Arial, sans-serif;
 }
   </style>
 </head>

--- a/guides/assets/icons.html
+++ b/guides/assets/icons.html
@@ -15,7 +15,7 @@
   <link rel="import"
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
   <link rel="import"
-        href="/bower_components/font-roboto/font-roboto.html">
+        href="/bower_components/font-roboto/roboto.html">
   <style>
 :root {
     --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',

--- a/guides/assets/tabs.html
+++ b/guides/assets/tabs.html
@@ -18,10 +18,10 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-body {
-    font-family: Roboto, 'Noto', 'Helvetica Neue',
-                 Helvetica, Arial, sans-serif;
-}
+    body {
+      font-family: Roboto, 'Noto', 'Helvetica Neue',
+                   Helvetica, Arial, sans-serif;
+    }
   </style>
 </head>
 <body class="fullbleed vertical layout">

--- a/guides/assets/tabs.html
+++ b/guides/assets/tabs.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">

--- a/guides/assets/tabs.html
+++ b/guides/assets/tabs.html
@@ -3,7 +3,6 @@
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">
   </script>
-  <link rel="import" href="/bower_components/polymer/polymer.html">
   <link rel="import"
         href="/bower_components/paper-header-panel/paper-header-panel.html">
   <link rel="import"

--- a/guides/assets/tabs.html
+++ b/guides/assets/tabs.html
@@ -18,9 +18,9 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-:root {
-    --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',
-                           Helvetica, Arial, sans-serif;
+body {
+    font-family: Roboto, 'Noto', 'Helvetica Neue',
+                 Helvetica, Arial, sans-serif;
 }
   </style>
 </head>

--- a/guides/assets/tabs.html
+++ b/guides/assets/tabs.html
@@ -17,7 +17,7 @@
   <link rel="import"
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
   <link rel="import"
-        href="/bower_components/font-roboto/font-roboto.html">
+        href="/bower_components/font-roboto/roboto.html">
   <style>
 :root {
     --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',

--- a/guides/assets/tall-header.html
+++ b/guides/assets/tall-header.html
@@ -12,10 +12,10 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-body {
-    font-family: Roboto, 'Noto', 'Helvetica Neue',
-                 Helvetica, Arial, sans-serif;
-}
+    body {
+      font-family: Roboto, 'Noto', 'Helvetica Neue',
+                   Helvetica, Arial, sans-serif;
+    }
   </style>
 </head>
 <body class="fullbleed vertical layout">

--- a/guides/assets/tall-header.html
+++ b/guides/assets/tall-header.html
@@ -11,7 +11,7 @@
   <link rel="import"
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
   <link rel="import"
-        href="/bower_components/font-roboto/font-roboto.html">
+        href="/bower_components/font-roboto/roboto.html">
   <style>
 :root {
     --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',

--- a/guides/assets/tall-header.html
+++ b/guides/assets/tall-header.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">

--- a/guides/assets/tall-header.html
+++ b/guides/assets/tall-header.html
@@ -12,9 +12,9 @@
   <link rel="import"
         href="/bower_components/font-roboto/roboto.html">
   <style>
-:root {
-    --primary-font-family: Roboto, 'Noto', 'Helvetica Neue',
-                           Helvetica, Arial, sans-serif;
+body {
+    font-family: Roboto, 'Noto', 'Helvetica Neue',
+                 Helvetica, Arial, sans-serif;
 }
   </style>
 </head>

--- a/guides/assets/tall-header.html
+++ b/guides/assets/tall-header.html
@@ -3,7 +3,6 @@
 <head>
   <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js">
   </script>
-  <link rel="import" href="/bower_components/polymer/polymer.html">
   <link rel="import"
         href="/bower_components/paper-header-panel/paper-header-panel.html">
   <link rel="import"


### PR DESCRIPTION
Hallo @frankiefu does this address your feedback? Thanks again.

CC @arthurevans @jeffposnick 

* Fix Roboto import. Was previously attempting to import from a non-existent file.
* Remove explicit Polymer import. Polymer is already imported by Paper/Iron/etc. elements.
* Add HTML5 doctype to each demo.
* Fix CSS rule for fonts. Was attempting to use a non-existent `--primary-font-family` variable on `:host`. Now just uses `font-family` on `body`.