### PR TITLE
Fix playAnimation parameter

### DIFF
--- a/guides/using-neon-animations.md
+++ b/guides/using-neon-animations.md
@@ -109,7 +109,7 @@ Polymer({
   hide: function() {
     this.opened = false;
     // run fade-out-animation
-    this.playAnimation('fade-out-animation');
+    this.playAnimation('exit');
   },
   _onNeonAnimationFinish: function() {
     if (!this.opened) {


### PR DESCRIPTION
The `playAnimation()` function should have the animation name as parameter and not its value.