### PR TITLE
fix search after app-router enhancement

### DIFF
--- a/app/elements/pages/page-browse.html
+++ b/app/elements/pages/page-browse.html
@@ -126,7 +126,7 @@
         pageTitle: {type: String},
 
         // Query Parameters
-        q: {type: String, notify: true, value: ''},
+        q: {type: String, notify: true, value: '', observer: '_qChanged'},
         tag: {type: String, notify: true, value: ''},
         package: {type: String, notify: true, value: ''},
         view: {type: String, notify: true},
@@ -160,7 +160,6 @@
 
       attached: function() {
         this.updateMeta();
-        this.updateSearch();
       },
 
       filter: function(element) {
@@ -236,15 +235,14 @@
       _packageLink: function(name) {
         return "/browse?package=" + name;
       },
-      updateSearch: function() {
-        var params = this._parseQueryString();
-        if (params && params.q) {
+      _qChanged: function(q) {
+        if (q) {
           this.async(function() {
             this.$.query.focus();
 
             // make sure to force the cursor to the end of the
             // input. Only an issue in Firefox.
-            this.$.query.setSelectionRange(params.q.length, params.q.length);
+            this.$.query.setSelectionRange(q.length, q.length);
           });
         }
       },


### PR DESCRIPTION
the search is broker after https://github.com/Polymer/polymer-element-catalog/pull/188.  It was
relying on the browse page being created everytime the app-router
switches to the page.  But with the enhancement in app-router we are no
longer re-creating the page so we need to move the input focus logic to
when `q` changes instead of in `attached`
