### PR TITLE
Improve layout and performance

### DIFF
--- a/app/elements/app-shell/app-shell.html
+++ b/app/elements/app-shell/app-shell.html
@@ -45,7 +45,6 @@
     <paper-toast id="toast"></paper-toast>
   </template>
 </dom-module>
-
 <script>
   Polymer({
     is: 'app-shell',

--- a/app/elements/app-sidebar/app-sidebar.css
+++ b/app/elements/app-sidebar/app-sidebar.css
@@ -1,6 +1,5 @@
 :host {
   height: 100%;
-  box-shadow: 0 0 8px rgba(0,0,0,0.4);
   box-sizing: border-box;
   z-index: 2;
   background: white;

--- a/app/elements/app-sidebar/app-sidebar.css
+++ b/app/elements/app-sidebar/app-sidebar.css
@@ -45,3 +45,7 @@
   padding: 0 24px;
   margin: 0;
 }
+
+::content .content {
+  @apply(--layout-vertical);
+}

--- a/app/elements/cart-item-icon/cart-item-icon.html
+++ b/app/elements/cart-item-icon/cart-item-icon.html
@@ -5,8 +5,8 @@
 <dom-module id="cart-item-icon">
   <style>
     iron-icon {
-      width: var(--cart-item-icon-size,24px);
-      height: var(--cart-item-icon-size,24px);
+      width: var(--cart-item-icon-size, 18px);
+      height: var(--cart-item-icon-size, 18px);
     }
 
     span {
@@ -16,7 +16,8 @@
   <template>
     <catalog-cart id="cart" on-item-added="_update" on-item-removed="_update" on-items-changed="_update"></catalog-cart>
 
-    <iron-icon icon="[[_icon]]"></iron-icon><span hidden$="[[noLabel]]">[[_label]]</span>
+    <iron-icon icon="[[_icon]]" title$="[[_label]]"></iron-icon>
+    <span hidden$="[[noLabel]]">[[_label]]</span>
   </template>
 </dom-module>
 

--- a/app/elements/element-action-menu/element-action-menu.html
+++ b/app/elements/element-action-menu/element-action-menu.html
@@ -3,39 +3,72 @@
 <link rel="import" href="../catalog-element/catalog-element.html">
 
 <dom-module id="element-action-menu">
-  <style>
-    :host {
-      @apply(--layout);
-      @apply(--layout-center);
-      @apply(--layout-center-justified);
-      position: relative;
-      text-align: center;
-    }
-
-    a, iron-icon {
-      color: rgba(0,0,0,0.6);
-    }
-
-    a {
-      margin: 0 5px;
-    }
-
-    iron-icon {
-      margin-right: 5px;
-      --iron-icon-size: 18px;
-    }
-
-    a[disabled] {
-      visibility: hidden;
-      pointer-events: none;
-    }
-  </style>
   <template>
+    <style>
+      :host {
+        @apply(--layout);
+        @apply(--layout-center);
+        @apply(--layout-center-justified);
+        position: relative;
+        text-align: center;
+        padding-top: 15px;
+        margin-right: 5px;
+      }
+
+      a, iron-icon {
+        font-size: 12px;
+        color: #666;
+        outline: none;
+      }
+
+      a {
+        margin: 0 5px;
+        cursor: pointer;
+      }
+
+      span {
+        width: 40px;
+        display: block;
+      }
+
+      a:hover,
+      a:hover iron-icon {
+        color: black;
+      }
+
+      iron-icon {
+        --iron-icon-width: 18px;
+        --iron-icon-height: 18px;
+      }
+
+      cart-item-icon {
+        --cart-item-icon-label: { 
+          display: block;
+          width: 40px;
+        };
+      }
+
+    </style>
     <catalog-element name="[[element]]" data="{{_element}}"></catalog-element>
-    <a tabindex="0" role="button" on-tap="cartAdd"><cart-item-icon id="cartItemIcon" element="[[element]]" present-label="Remove" absent-label="Add" no-label="[[iconsOnly]]"></cart-item-icon></a>
-    <a tabindex="0" role="button" on-click="navToDocs" aria-label="View Docs"><iron-icon icon="description" title="View Docs"></iron-icon><span hidden$="[[iconsOnly]]">Docs</span></a>
-    <a tabindex="0" role="button" href="[[githubLink(_element.source)]]" target="_blank" title="View Source on GitHub" aria-label="View Source on GitHub"><iron-icon icon="code"></iron-icon><span hidden$="[[iconsOnly]]">Source</span></a>
-    <a tabindex="0" role="button" on-click="navToDemo" disabled$="[[!_element.demo]]" aria-label="View Demo"><iron-icon icon="visibility" title="View Demo"></iron-icon><span hidden$="[[iconsOnly]]">Demo</span></a>
+
+    <a tabindex="0" role="button" on-tap="cartAdd">
+      <cart-item-icon id="cartItemIcon" element="[[element]]" present-label="Remove" absent-label="Add" no-label="[[iconsOnly]]"></cart-item-icon>
+    </a>
+
+    <a tabindex="0" role="button" on-click="navToDocs" aria-label="View Docs">
+      <iron-icon icon="description" title="View Docs"></iron-icon>
+      <span hidden$="[[iconsOnly]]">Docs</span>
+    </a>
+
+    <a tabindex="0" role="button" href="[[githubLink(_element.source)]]" target="_blank" title="View Source on GitHub" aria-label="View Source on GitHub">
+      <iron-icon icon="code"></iron-icon>
+      <span hidden$="[[iconsOnly]]">Source</span>
+    </a>
+
+    <a tabindex="0" role="button" on-click="navToDemo" hidden$="[[!_element.demo]]" aria-label="View Demo">
+      <iron-icon icon="visibility" title="View Demo"></iron-icon>
+      <span hidden$="[[iconsOnly]]">Demo</span>
+    </a>
   </template>
 </dom-module>
 

--- a/app/elements/element-table/element-table.html
+++ b/app/elements/element-table/element-table.html
@@ -22,7 +22,7 @@
       line-height: 56px;
       font-size: 12px;
       font-weight: 500;
-      color: rgba(0, 0, 0, 0.54);
+      color: black
     }
 
     #element-table td, #element-table th {
@@ -64,12 +64,12 @@
     #element-table :focus element-action-menu::shadow iron-icon,
     #element-table element-action-menu::shadow a:focus iron-icon
     {
-      color: #616161;
+      color: black;
     }
 
     #element-table .description {
       overflow: hidden;
-      color: #606060;
+      color: black
       overflow: hidden;
       text-overflow: ellipsis;
       max-width: 400px;
@@ -106,11 +106,11 @@
   <template>
     <table id="element-table">
       <thead>
-        <tr>
-          <th class="name">Name</th>
-          <th class="description">Description</th>
-          <th class="tags">Tags</th>
-          <th class="actions">Action</th>
+        <tr style$="[[_getHeaderStyle(color)]]">
+          <th>Name</th>
+          <th>Description</th>
+          <th>Tags</th>
+          <th>Action</th>
         </tr>
       </thead>
       <tbody>
@@ -119,7 +119,7 @@
             <td class="name" width="100">[[item.name]]</td>
             <td class="description relative">[[item.description]]</td>
             <td class="tags">
-              <template is="dom-repeat" items="[[item.tags]]" as="tag">
+             <template is="dom-repeat" items="[[item.tags]]" as="tag">
                 <tag-link name="[[tag]]" on-tap="tagTapped"></tag-link><span
                   hidden$="[[_isLastItem(index, item.tags.length)]]">,</span>
               </template>
@@ -138,7 +138,8 @@
 Polymer({
   is: 'element-table',
   properties: {
-    elements: Array
+    elements: Array,
+    color: String
   },
   tagTapped: function(e) {
     e.preventDefault();
@@ -170,6 +171,9 @@ Polymer({
   },
   _isLastItem: function(index, length) {
     return (index === length - 1);
+  },
+  _getHeaderStyle: function(color) {
+    return 'background-color: '+ color+';';
   }
 });
 </script>

--- a/app/elements/element-table/element-table.html
+++ b/app/elements/element-table/element-table.html
@@ -4,176 +4,208 @@
 <link rel="import" href="../tag-link/tag-link.html">
 
 <dom-module id="element-table">
-  <style>
-    :host {
-      display: block;
-    }
-
-    #element-table {
-      width: 100%;
-      border-collapse: collapse;
-      background: white;
-      border-radius: 3px;
-      border: 1px solid #e5e5e5;
-    }
-
-    #element-table thead th {
-      padding: 0 24px;
-      line-height: 56px;
-      font-size: 12px;
-      font-weight: 500;
-      color: black
-    }
-
-    #element-table td, #element-table th {
-      padding: 12px 24px;
-    }
-
-    #element-table td.tags {
-      font-size: 11px;
-      line-height: 16px;
-      font-weight: 400;
-    }
-
-    #element-table th {
-      @apply(--paper-font-body1);
-      color: var(--secondary-text-color);
-      text-align: left;
-      border-bottom: 1px solid;
-      border-bottom-color: #e5e5e5;
-    }
-
-    #element-table tbody tr {
-      cursor: pointer;
-      overflow: hidden;
-      height: 48px;
-    }
-
-    #element-table tbody tr:first-child {
-      margin-top: 8px;
-    }
-
-    #element-table element-action-menu::shadow iron-icon {
-      color: #e0e0e0;
-      margin: 0 4px;
-      width: 18px;
-      height: 18px;
-    }
-
-    #element-table tr:hover element-action-menu::shadow iron-icon,
-    #element-table :focus element-action-menu::shadow iron-icon,
-    #element-table element-action-menu::shadow a:focus iron-icon
-    {
-      color: black;
-    }
-
-    #element-table .description {
-      overflow: hidden;
-      color: black
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 400px;
-    }
-
-    #element-table tbody tr:hover {
-      background: #fafafa;
-    }
-
-    #element-table a {
-      font-weight: bold;
-    }
-
-    #element-table a, #element-tableiron-icon {
-      cursor: pointer;
-    }
-
-    [size=xs] #element-table.description {
-      display: none;
-    }
-
-    #element-table .name {
-      white-space: nowrap;
-      font-weight: 400;
-      font-size: 13px;
-    }
-
-    #element-table .description {
-      color: var(--secondary-text-color);
-      line-height: 24px;
-    }
-  </style>
-
   <template>
-    <table id="element-table">
-      <thead>
-        <tr style$="[[_getHeaderStyle(color)]]">
-          <th>Name</th>
-          <th>Description</th>
-          <th>Tags</th>
-          <th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        <template is="dom-repeat" items="[[elements]]">
-          <tr on-tap="nav" target$="[[item.name]]" tabindex="0">
-            <td class="name" width="100">[[item.name]]</td>
-            <td class="description relative">[[item.description]]</td>
-            <td class="tags">
-             <template is="dom-repeat" items="[[item.tags]]" as="tag">
-                <tag-link name="[[tag]]" on-tap="tagTapped"></tag-link><span
-                  hidden$="[[_isLastItem(index, item.tags.length)]]">,</span>
-              </template>
-            </td>
-            <td class="actions">
-              <element-action-menu element="[[item.name]]" icons-only></element-action-menu>
-            </td>
-          </tr>
-        </template>
-      </tbody>
-    </table>
+    <style>
+      :host {
+        display: block;
+        position: relative;
+        background: white;
+        border: 1px solid #e5e5e5;
+        border-radius: 3px;
+      }
+
+      .header {
+        padding: 0 24px;
+        line-height: 56px;
+        font-size: 12px;
+        font-weight: 500;
+        border-bottom: 1px solid #e5e5e5;
+      }
+
+      :host([narrow-viewport]) .header .description {
+        display: none;
+      }
+
+      :host(:not([narrow-viewport])) .header,
+      :host(:not([narrow-viewport])) .row,
+      :host(:not([narrow-viewport])) .row a {
+        @apply(--layout-horizontal);
+      }
+
+      :host([narrow-viewport]) .header,
+      :host([narrow-viewport]) .row,
+      :host([narrow-viewport]) .row a {
+        @apply(--layout-vertical);
+      }
+
+      .row {
+        border-bottom: 1px solid #e5e5e5;
+      }
+
+      .row a {
+        box-sizing: border-box;
+        cursor: pointer;
+        overflow: hidden;
+        width: 100%;
+        padding: 15px 24px;
+        font-weight: 400;
+        font-size: 13px;
+      }
+
+      .row.hover {
+        background: #fafafa;
+      }
+
+      :host(:not([narrow-viewport])) .row.hover .description {
+        padding-right: 120px;
+      }
+
+      .name {
+        min-width: 250px;
+      }
+
+      .name .narrow {
+        display: none;
+      }
+
+      :host([narrow-viewport])  .name .narrow {
+        display: inline;
+      }
+
+      .row .description {
+        color: #757575;
+      }
+
+      :host(:not([narrow-viewport])) .row .description {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      #actions element-action-menu {
+        position: absolute;
+        right: 0;
+      }
+
+    </style>
+    <iron-media-query query="(max-width: 640px)" query-matches="{{narrowViewport}}"></iron-media-query>
+
+    <div class="header" style$="[[_getHeaderStyle(color)]]">
+      <div class="name">Name <span class="narrow">/ Description</span></div>
+      <div class="description">Description</div>
+    </div>
+    <template is="dom-repeat" items="[[elements]]">
+      <div class="row" data-index$="[[index]]">
+        <a href$="[[_elementLink(item.name)]]">
+          <div class="name">[[item.name]]</div>
+          <div class="description">[[item.description]]</div>
+        </a>
+      </div>
+    </template>
+    <div id="actions"></div>
   </template>
 </dom-module>
-
 <script>
-Polymer({
-  is: 'element-table',
-  properties: {
-    elements: Array,
-    color: String
-  },
-  tagTapped: function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    this.fire('tag-selected', {name: e.currentTarget.name});
-  },
-  nav: function(e, detail) {
-    var target = e.target;
-    while (target && target !== e.currentTarget) {
-      if (target.href && target.href.indexOf('//') >= 0) {
-        return true;
+  Polymer({
+    is: 'element-table',
+
+    properties: {
+      elements: Array,
+      color: String,
+      narrowViewport: {type: Boolean, reflectToAttribute: true}
+    },
+
+    listeners: {
+      'tap': '_tap',
+      'mouseover': '_mouseOver',
+      'mouseleave': '_mouseLeave'
+    },
+
+    _currentRowIndex: -1,
+
+    _sharedActionMenu: null,
+
+    _findAncestor: function(node, fn) {
+      while (node && fn.call(this, node)) {
+        node = node.parentNode;
       }
-      target = target.parentNode;
-    }
+      return node;
+    },
 
-    e.stopPropagation();
-    e.preventDefault();
+    _tap: function(e) {
+      var sourceEvent = e.detail.sourceEvent;
+      var A = this._findAncestor(e.target, function(node) {
+        return node != this && node.tagName !== 'A';
+      });
 
-    var se = detail.sourceEvent || {};
-    var url = "/elements/" + e.currentTarget.getAttribute('target');
-    if (se.ctrlKey || se.metaKey) {
-      window.open(url);
-    } else {
-      this.fire('nav', {url: url});
+      if (A && A.tagName === 'A' && A.href.indexOf(location.host) > 0) {
+        if (sourceEvent.ctrlKey || sourceEvent.metaKey) {
+          window.open(A.href);
+        } else {
+          this.fire('nav', {url: A.href});
+        }
+        e.preventDefault();
+      }
+    },
+
+    _mouseOver: function(e) {
+      var row = this._findAncestor(e.target, function(node) {
+        return node != this && !node.classList.contains('row') && node.id !== 'actions';
+      });
+      if (row && row.classList.contains('row')) {
+        if (this._currentRowIndex != row.dataset.index) {
+          this._hideActions();
+          this._showActions(row, row.dataset.index);
+        }
+      } else if (row.id !== 'actions') {
+        this._hideActions();
+      }
+    },
+
+    _mouseLeave: function() {
+      this._hideActions();
+    },
+
+    _showActions: function(row, index) {
+      var sharedActionMenu = this._sharedActionMenu;
+      var rowOffsetTop = row.offsetTop;
+
+      if (!sharedActionMenu) {
+        this._sharedActionMenu = document.createElement('element-action-menu');
+        Polymer.dom(this.$.actions).appendChild(this._sharedActionMenu);
+        sharedActionMenu = this._sharedActionMenu;
+      }
+
+      sharedActionMenu.iconsOnly = true;
+      sharedActionMenu.element = this.elements[index].name;
+      sharedActionMenu.style.top = rowOffsetTop + 'px';
+      sharedActionMenu.style.display = '';
+      row.classList.add('hover');
+
+      this._currentRowIndex = index;
+      this._currentRow = row;
+    },
+
+    _hideActions: function() {
+      var row = this._currentRow;
+      var sharedActionMenu = this._sharedActionMenu;
+
+      if (row) {
+        if (sharedActionMenu) {
+          sharedActionMenu.style.display = 'none';
+        }
+        row.classList.remove('hover');
+        this._currentRowIndex = -1;
+        this._currentRow = null;
+      }
+    },
+
+    _elementLink: function(name) {
+      return "/elements/" + name;
+    },
+
+    _getHeaderStyle: function(color) {
+      return 'background-color: '+ color+';';
     }
-  },
-  _elementLink: function(name) {
-    return "/elements/" + name;
-  },
-  _isLastItem: function(index, length) {
-    return (index === length - 1);
-  },
-  _getHeaderStyle: function(color) {
-    return 'background-color: '+ color+';';
-  }
-});
+  });
 </script>

--- a/app/elements/pages/page-browse.css
+++ b/app/elements/pages/page-browse.css
@@ -34,10 +34,10 @@ app-bar .menu-icon {
   color: var(--paper-grey-600);
 }
 
-#element-cards, element-table, .elements-title, #package-heading {
-  width: 100%;
+#element-cards, element-table, 
+.elements-title, #package-heading {
   max-width: 920px;
-  margin: 10px auto;
+  margin: 20px auto;
 }
 
 #package-heading {
@@ -171,23 +171,40 @@ app-sidebar paper-toolbar {
 
 #search {
   height: 48px;
-  border-bottom: 1px solid #e5e5e5;
-  border-top: 1px solid #e5e5e5;
   line-height: 48px;
   margin-bottom: 12px;
+  position: relative;
 }
 
 #search iron-icon {
   margin-left: 16px;
   margin-right: 8px;
+  position: absolute;
+  top: 12px;
+  left: 2px;
 }
 
 #search input {
   height: 46px;
+  -webkit-appearance: none;
   line-height: 46px;
   border: 0;
+  margin: 0;
+  padding-left: 50px;
+  border-bottom: 1px solid #e5e5e5;
+  border-top: 1px solid #e5e5e5;
   @apply(--paper-font-body1);
-  margin-right: 16px;
+}
+
+#search input:focus {
+  outline: 0;
+  background-color: #eceff1;
+  border-color: #cfd8dc;
+}
+
+#search input::-webkit-search-cancel-button{
+  position: relative;
+  right: 15px;
 }
 
 #package-list {
@@ -221,21 +238,6 @@ app-sidebar paper-toolbar {
 
 #package-list .package package-symbol, #package-list .package .all-symbol {
   margin-right: 15px;
-}
-
-[size=xs] .elements-title,
-[size=s] .elements-title,
-[size=m] .elements-title {
-  width: 100%;
-  margin: 0;
-  padding: 2px 0;
-}
-
-[size=xs] element-table,
-[size=s] element-table,
-[size=m] element-table {
-  margin: 10px 16px;
-  width: calc(100% - 32px);
 }
 
 #current-tag {

--- a/app/elements/pages/page-browse.css
+++ b/app/elements/pages/page-browse.css
@@ -20,18 +20,6 @@ app-bar .menu-icon {
   color: #424242;
 }
 
-.elements-title .count {
-  color: var(--paper-grey-600);
-}
-
-.elements-title .count:before {
-  content: "(";
-}
-
-.elements-title .count:after {
-  content: ")";
-}
-
 .elements-title iron-icon, .elements-title cart-icon {
   cursor: pointer;
   margin-left: 16px;
@@ -90,8 +78,6 @@ responsive-element[size=xs].layout {
 app-sidebar paper-toolbar {
   --paper-toolbar-background: white;
   --paper-toolbar: {
-    border-bottom: 1px solid;
-    border-bottom-color: var(--divider-color);
     box-sizing: border-box;
   }
 }
@@ -222,13 +208,11 @@ app-sidebar paper-toolbar {
   color: rgba(0,0,0,.87);
   text-transform: none;
   cursor: pointer;
-  border: 1px solid transparent;
   border-width: 1px 0;
 }
 
 #package-list .package[active] {
   background: var(--paper-blue-grey-50);
-  border-color: var(--paper-blue-grey-100);
 }
 
 #package-list .package .all-symbol {

--- a/app/elements/pages/page-browse.html
+++ b/app/elements/pages/page-browse.html
@@ -23,8 +23,6 @@
   <template>
     <catalog-data elements="{{elements}}" packages="{{packages}}"></catalog-data>
     <catalog-package name="[[package]]" data="{{packageInfo}}"></catalog-package>
-    <iron-media-query query="(max-width: 640px)" query-matches="{{_narrowViewport}}"></iron-media-query>
-
     <responsive-element>
       <paper-drawer-panel id="drawerPanel" responsive-width="900px" drawer-width="272px" disable-edge-swipe>
         <app-sidebar drawer>
@@ -58,34 +56,13 @@
                 </template>
               </nav>
             </div>
-            <div id="tags">
-              <!--<h5>Tags</h5>-->
-            </div>
-            <!--<div id="package-info" hidden$="[[!packageInfo.name]]">
-              <div id="package-header">
-                <package-symbol package="[[packageInfo]]" class="large"></package-symbol>
-                <h2 id="package-title">[[packageInfo.title]]</h2>
-                <span id="package-version">[[packageInfo.version]]</span>
-                <h4 id="package-tagline">[[packageInfo.tagline]]</h4>
-              </div>
-              <div id="package-details">
-                <div class="section">
-                  <h5>Product Description</h5>
-                  <p id="package-desc">[[packageInfo.description]]</p>
-                </div>
-                <div class="section">
-                  <h5>Tags</h5>
-
-                </div>
-              </div>
-            </div>-->
             <div hidden$="[[!tag]]" id="current-tag" class="horizontal layout center">
               <b>Tag:</b> <span class="flex">[[tag]]</span> <iron-icon icon="clear" on-tap="clearTag"></iron-icon>
             </div>
           </div>
         </app-sidebar>
 
-        <div id="container" class="fit" view$="[[_actualView(view,_narrowViewport)]]" main>
+        <div id="container" class="fit" view$="[[_actualView(view)]]" main>
           <div class="elements-title horizontal layout center">
             <iron-icon icon="menu" paper-drawer-toggle></iron-icon>
             <h2 class="flex">[[pageTitle]]</h2>
@@ -98,14 +75,14 @@
           </div>
 
           <div id="element-cards" class="horizontal layout wrap">
-            <template is="dom-if" if="[[_stampCards(view,_forceCards)]]">
+            <template is="dom-if" if="[[_stampCards(view)]]" restamp>
               <template name="element-cards-repeat" is="dom-repeat" items="[[_filteredElements]]">
                 <element-card element="[[item.name]]"></element-card>
               </template>
             </template>
           </div>
 
-          <template is="dom-if" if="[[_stampTable(view,_forceCards)]]">
+          <template is="dom-if" if="[[_stampTable(view)]]" restamp>
             <element-table color="[[packageInfo.color]]" elements="[[_filteredElements]]" on-tag-selected="updateTag"></element-table>
           </template>
         </div>
@@ -140,7 +117,6 @@
 
         _filteredElements: Array,
         _elementCount: Number,
-        _narrowViewport: {type: Boolean, observer: '_updateForceCards'},
         _forceCards: {type: Boolean},
       },
       observers: [
@@ -153,7 +129,6 @@
       },
 
       ready: function() {
-        this._updateForceCards();
         this.view = this._forceCards ? 'cards' : 'table';
       },
 
@@ -263,7 +238,7 @@
           var t = "'" + this.q + "' ";
           t += (this.packageInfo && this.packageInfo.title) ? this.packageInfo.title : "Elements";
           this.pageTitle = t;
-        } else if (this.packageInfo) {
+        } else if (this.packageInfo && this.packageInfo.title) {
           this.pageTitle = this.packageInfo.title;
         } else if (this.tagList.length) {
           this.pageTitle = "Elements Tagged '" + this.tagList.join("' or '") + "'";
@@ -272,6 +247,7 @@
         }
 
         this.fire('page-meta', { title: this.pageTitle });
+        this.$.drawerPanel.closeDrawer();
       },
       toggleView: function() {
         if (this.view === 'table') {
@@ -302,40 +278,17 @@
       scrollToTop: function() {
         this.$.container.scrollTop = 0;
       },
-      _stampCards: function(view,stamp) {
-        return stamp || view === 'cards';
+      _stampCards: function(view) {
+        return view === 'cards';
       },
-      _stampTable: function(view, skip) {
-        return !skip && view === 'table';
+      _stampTable: function(view) {
+        return view === 'table';
       },
       closeDrawer: function() {
         this.$.drawerPanel.closeDrawer();
       },
-      _detectIEVersion: function () {
-        // via http://stackoverflow.com/questions/17907445/how-to-detect-ie11
-        var rv = -1;
-        var ua, re;
-        if (navigator.appName === 'Microsoft Internet Explorer')
-        {
-          ua = navigator.userAgent;
-          re  = new RegExp("MSIE ([0-9]{1,}[\.0-9]{0,})");
-          if (re.exec(ua) !== null)
-            rv = parseFloat( RegExp.$1 );
-        }
-        else if (navigator.appName === 'Netscape')
-        {
-          ua = navigator.userAgent;
-          re  = new RegExp("Trident/.*rv:([0-9]{1,}[\.0-9]{0,})|Edge/([0-9]{1,}[\.0-9]{0,})");
-          if (re.exec(ua) !== null)
-            rv = parseFloat( RegExp.$1 );
-        }
-        return rv;
-      },
       _actualView: function(view, force) {
         return force ? 'cards' : view;
-      },
-      _updateForceCards: function() {
-        this._forceCards = this._narrowViewport || this._detectIEVersion() > 0;
       },
       _isEqual: function(a,b) {
         return a === b;

--- a/app/elements/pages/page-browse.html
+++ b/app/elements/pages/page-browse.html
@@ -41,7 +41,6 @@
               <span>[[tag]]</span> <iron-icon icon="clear" on-tap="clearTag"></iron-icon>
             </div>
             <div id="package-list">
-              <h5>Products</h5>
               <nav>
                 <a class="package" is="app-link" href="/browse?package=" active$="[[_isEqual(package,'')]]" tabindex="1">
                   <div class="layout horizontal center">
@@ -89,7 +88,7 @@
         <div id="container" class="fit" view$="[[_actualView(view,_narrowViewport)]]" main>
           <div class="elements-title horizontal layout center">
             <iron-icon icon="menu" paper-drawer-toggle></iron-icon>
-            <h2 class="flex"><span>[[pageTitle]]</span> <span class="count">[[_elementCount]]</span></h2>
+            <h2 class="flex">[[pageTitle]]</h2>
             <iron-icon id="package-view-mode" icon="[[viewIcon]]" on-tap="toggleView" hidden$="[[_forceCards]]"></iron-icon>
             <cart-icon id="cart-toggle" icon="stars" on-tap="cartOpen"></cart-icon>
           </div>
@@ -107,7 +106,7 @@
           </div>
 
           <template is="dom-if" if="[[_stampTable(view,_forceCards)]]">
-            <element-table elements="[[_filteredElements]]" on-tag-selected="updateTag"></element-table>
+            <element-table color="[[packageInfo.color]]" elements="[[_filteredElements]]" on-tag-selected="updateTag"></element-table>
           </template>
         </div>
       </paper-drawer-panel>

--- a/app/elements/pages/page-element.css
+++ b/app/elements/pages/page-element.css
@@ -10,8 +10,6 @@ responsive-element[size=xs].layout {
 app-sidebar paper-toolbar {
   --paper-toolbar-background: white;
   --paper-toolbar: {
-    border-bottom: 1px solid;
-    border-bottom-color: var(--divider-color);
     box-sizing: border-box;
   }
 }

--- a/app/elements/pages/page-element.css
+++ b/app/elements/pages/page-element.css
@@ -108,6 +108,12 @@ section[main] {
   background: #fafafa;
 }
 
+iron-component-page {
+  --iron-component-page-container: {
+  };
+  --iron-component-page-max-width: 920px;
+}
+
 [narrow] iron-component-page {
   top: 56px;
 }
@@ -179,4 +185,13 @@ cart-item-icon {
   border-radius: 2px;
   font-size: 12px;
   color: var(--paper-blue-grey-500);
+}
+
+cart-icon {
+  transition: opacity 0.2;
+  -webkit-transition: opacity 0.2s;
+}
+
+cart-icon[fade-out] {
+  opacity: 0;
 }

--- a/app/elements/pages/page-element.html
+++ b/app/elements/pages/page-element.html
@@ -25,7 +25,7 @@
     <catalog-data elements="{{elements}}" behavior-map="{{behaviorMap}}"></catalog-data>
 
     <theme-color color="[[package.color]]">
-      <paper-drawer-panel drawer-width="272px" disable-edge-swipe>
+      <paper-drawer-panel id="drawerPanel" drawer-width="272px" disable-edge-swipe>
         <app-sidebar drawer>
           <paper-toolbar>
             <app-logo class="flex"></app-logo>
@@ -72,7 +72,6 @@
 
             <section class="shrinkable" hidden$="[[_oneOrFewer(docBehaviors, docElements)]]">
               <h4>Bundled Behaviors</h4>
-
               <nav id="elnav" class="nav" attr-for-selected="name" selected="[[active]]">
                 <template is="dom-repeat" items="[[docBehaviors]]">
                   <a is="app-link" class="item" href$="[[_link(item.is,view)]]" active$="[[_isEqual(item.is,active)]]">[[item.is]]</a>
@@ -93,7 +92,7 @@
         <section main class="fit">
           <iron-component-page on-iron-doc-viewer-component-selected="navToBehavior" version="[[metadata.version]]" doc-src="[[docSrc(element)]]" base="[[baseURI(element)]]" _catalog view="{{view}}" doc-elements="{{docElements}}" doc-behaviors="{{docBehaviors}}" doc-demos="{{docDemos}}" active="{{active}}"></iron-component-page>
           <iron-icon icon="menu" paper-drawer-toggle></iron-icon>
-          <cart-icon></cart-icon>
+          <cart-icon fade-out$="[[_isCartIconHidden(view)]]"></cart-icon>
         </section>
       </paper-drawer-panel>
     </theme-color>
@@ -119,6 +118,7 @@
     },
     observers: [
       'updateMeta(element,active)',
+      'viewUpdated(view)',
       'analyze(importPath)',
       'search(q)'
     ],
@@ -149,7 +149,11 @@
       return url;
     },
     updateMeta: function(element,active) {
+      this.$.drawerPanel.closeDrawer();
       this.fire('page-meta', {title: (this.active && this.active.length) ? this.active : this.element});
+    },
+    viewUpdated: function() {
+      this.$.drawerPanel.closeDrawer();
     },
     _packageLink: function() {
       return "/browse?package=" + this.package.name;
@@ -204,6 +208,9 @@
     },
     _selectAllBowerCommand: function(e) {
       e.currentTarget.select();
+    },
+    _isCartIconHidden: function(view) {
+      return view.indexOf('demo:') === 0;
     }
   });
 </script>


### PR DESCRIPTION
This is the last update to the catalog to improve the performance and the UI.
- [x] Tested in Safari (mobile & desktop), firefox, chrome (mobile & desktop)

**Issues**
1. Improve performance of `<element-table>`.  
   - Move from table to flex layout. 
   - Create a single instance of `<element-action-menu>`
   - Use event delegation
   - A11y: Users can now navigate to the elements by keyboard.
2. Improve the performance of `<page-browse>` 
   - Restamp the two internal dom-if templates if the view changed. This helped a lot. 
3. Change the brackground color of the header of  `<element-table>` so it matches the element category.
4. Make `<element-table>` responsible.
5. Hide the drawer after tapping a section if the drawer-panel is in narrow mode.
6. A few other minor touch ups.
   - Hide the collection button when looking at a demo.

**Required:**
- [ ] https://github.com/PolymerElements/iron-component-page/pull/59
