### PR TITLE
Added paper-styles as import.

### DIFF
--- a/guides/responsive-material-design-layouts.md
+++ b/guides/responsive-material-design-layouts.md
@@ -72,6 +72,8 @@ children are placed in the content area.
         href="/bower_components/paper-toolbar/paper-toolbar.html">
   <link rel="import" 
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
+  <link rel="import"
+        href="/bower_components/paper-styles/paper-styles.html">
 ...
 <body class="fullbleed vertical layout">
   <!-- paper-header-panel must have an explicit height -->
@@ -121,6 +123,8 @@ You can use another element as a header by adding the
         href="/bower_components/paper-header-panel/paper-header-panel.html">
   <link rel="import" 
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
+  <link rel="import"
+        href="/bower_components/paper-styles/paper-styles.html">
 ...
 <body class="fullbleed vertical layout">
   <paper-header-panel class="flex">
@@ -154,6 +158,8 @@ Use `paper-icon-button` and `iron-icons` to add icons to your header:
         href="/bower_components/iron-icons/iron-icons.html">
   <link rel="import" 
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
+  <link rel="import"
+        href="/bower_components/paper-styles/paper-styles.html">
 ...
 <body class="fullbleed vertical layout">
   <paper-header-panel class="flex">
@@ -199,6 +205,8 @@ classes to change the height of your header.
         href="/bower_components/paper-toolbar/paper-toolbar.html">
   <link rel="import" 
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
+  <link rel="import"
+        href="/bower_components/paper-styles/paper-styles.html">
 ...
 <body class="fullbleed vertical layout">
   <paper-header-panel class="flex">
@@ -235,6 +243,8 @@ Use `paper-tabs` to add tabs to your header:
         href="/bower_components/iron-icons/iron-icons.html">
   <link rel="import" 
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
+  <link rel="import"
+        href="/bower_components/paper-styles/paper-styles.html">
 ...
 <body class="fullbleed vertical layout">
   <paper-header-panel class="flex">
@@ -307,6 +317,8 @@ navigation menu.
         href="/bower_components/iron-icons/iron-icons.html">
   <link rel="import" 
         href="/bower_components/iron-flex-layout/iron-flex-layout.html">
+  <link rel="import"
+        href="/bower_components/paper-styles/paper-styles.html">
 ...
 <body class="fullbleed vertical layout">
   <paper-drawer-panel class="flex">


### PR DESCRIPTION
Added paper-styles as import. Without it the paper-header-panel or the paper-drawer-panel won't render properly, both panel won't occupy the entire top part of browser window and the content won't show.