### PR TITLE
Remove /deep/ and :shadow styling

### DIFF
--- a/app/elements/app-bar/app-bar.html
+++ b/app/elements/app-bar/app-bar.html
@@ -1,6 +1,6 @@
 <dom-module id="app-bar">
   <!--<link rel="import" type="css" href="app-bar.css">-->
-  <style>
+  <style include="iron-flex">
     :host * {
       box-sizing: border-box;
     }

--- a/app/elements/app-logo/app-logo.html
+++ b/app/elements/app-logo/app-logo.html
@@ -6,7 +6,7 @@
 </style>
 
 <dom-module id="app-logo">
-  <style>
+  <style include="iron-flex">
     :host {
       font-size: var(--app-logo-font-size);
     }

--- a/app/elements/app-styles/app-styles.html
+++ b/app/elements/app-styles/app-styles.html
@@ -1,10 +1,8 @@
-<link rel="import" href="../../bower_components/paper-styles/paper-styles.html">
-
 <style is="custom-style">
   * {
     box-sizing: border-box;
   }
-  
+
   :root {
     --iron-icon-size: 24px;
 

--- a/app/elements/element-card/element-card.html
+++ b/app/elements/element-card/element-card.html
@@ -3,13 +3,12 @@
 
 <link rel="import" href="../catalog-element/catalog-element.html">
 <link rel="import" href="../catalog-package/catalog-package.html">
-<link rel="import" href="../hero-image/hero-image.html">
 <link rel="import" href="../package-symbol/package-symbol.html">
 <link rel="import" href="../element-action-menu/element-action-menu.html">
 
 <dom-module id="element-card">
   <template>
-    <style>
+    <style include="iron-flex">
       :host {
         display: block;
         margin: 10px 10px 10px 0;

--- a/app/elements/element-table/element-table.html
+++ b/app/elements/element-table/element-table.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../../bower_components/paper-styles/paper-styles.html">
+<link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout.html">
 
 <link rel="import" href="../element-action-menu/element-action-menu.html">
 <link rel="import" href="../tag-link/tag-link.html">

--- a/app/elements/elements.html
+++ b/app/elements/elements.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../bower_components/polymer/polymer.html">
-<link rel="import" href="../bower_components/iron-flex-layout/classes/iron-shadow-flex-layout.html">
-<link rel="import" href="../bower_components/paper-styles/paper-styles.html">
+<link rel="import" href="../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="../bower_components/prism-element/prism-highlighter.html">
 <link rel="import" href="../bower_components/pushstate-anchor/pushstate-anchor.html">
-
+<link rel="import" href="../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="app-shell/app-shell.html">

--- a/app/elements/hero-image/hero-image.html
+++ b/app/elements/hero-image/hero-image.html
@@ -12,13 +12,9 @@
     iron-image {
       @apply(--layout-fit);
     }
-
-    iron-image::shadow img {
-      fill: white;
-    }
   </style>
   <template>
-    
+
   </template>
 </dom-module>
 

--- a/app/elements/pages/page-browse.css
+++ b/app/elements/pages/page-browse.css
@@ -62,7 +62,7 @@ app-bar .menu-icon {
   color: var(--paper-grey-600);
 }
 
-#element-cards, element-table, 
+#element-cards, element-table,
 .elements-title, #package-heading {
   max-width: 920px;
   margin: 20px auto;
@@ -85,10 +85,6 @@ responsive-element[size=xs].layout {
 [size=xs] app-sidebar {
   min-width: 100%;
   height: auto;
-}
-
-[size=xs] app-sidebar paper-toolbar /deep/ #topBar {
-  padding: 0 16px;
 }
 
 app-sidebar paper-toolbar {

--- a/app/elements/pages/page-browse.html
+++ b/app/elements/pages/page-browse.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../bower_components/iron-selector/iron-selector.html">
 <link rel="import" href="../../bower_components/iron-icons/iron-icons.html">
+<link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="../../bower_components/iron-icons/av-icons.html">
 <link rel="import" href="../../bower_components/paper-drawer-panel/paper-drawer-panel.html">
 <link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
@@ -17,11 +18,13 @@
 <link rel="import" href="../element-action-menu/element-action-menu.html">
 <link rel="import" href="../element-table/element-table.html">
 <link rel="import" href="../element-table-cards/element-table-cards.html">
+
 <link rel="import" href="../responsive-element/responsive-element.html">
 
 <dom-module id="page-browse">
   <link rel="import" type="css" href="page-browse.css">
   <template>
+    <style include="iron-flex iron-flex-alignment"></style>
     <catalog-data elements="{{elements}}" packages="{{packages}}"></catalog-data>
     <catalog-package name="[[package]]" data="{{packageInfo}}"></catalog-package>
       <paper-drawer-panel id="drawerPanel" responsive-width="900px" narrow="{{narrowMode}}" drawer-width="272px" disable-edge-swipe>

--- a/app/elements/pages/page-element.css
+++ b/app/elements/pages/page-element.css
@@ -14,10 +14,6 @@ app-sidebar paper-toolbar {
   }
 }
 
-[size=xs] app-sidebar paper-toolbar /deep/ #topBar {
-  padding: 0 16px;
-}
-
 #package-heading {
   height: 48px;
   line-height: 48px;

--- a/app/elements/pages/page-element.html
+++ b/app/elements/pages/page-element.html
@@ -20,6 +20,7 @@
 <dom-module id="page-element">
   <link rel="import" type="css" href="page-element.css">
   <template>
+    <style include="iron-flex iron-flex-alignment"></style>
     <catalog-element name="[[element]]" data="{{metadata}}"></catalog-element>
     <catalog-package name="[[metadata.package]]" data="{{package}}"></catalog-package>
     <catalog-data elements="{{elements}}" behavior-map="{{behaviorMap}}"></catalog-data>
@@ -79,7 +80,7 @@
           </div>
         </app-sidebar>
         <section main class="fit">
-          <iron-component-page 
+          <iron-component-page
             catalog
             id="componentPage"
             scroll-mode="[[_getScrollMode(narrowDrawer)]]"

--- a/app/elements/pages/page-guide.html
+++ b/app/elements/pages/page-guide.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
-<link rel="import" href="../../bower_components/paper-styles/paper-styles.html">
+<link rel="import" href="../../bower_components/paper-styles/shadow.html">
 <link rel="import" href="../../bower_components/paper-drawer-panel/paper-drawer-panel.html">
 
 <link rel="import" href="../catalog-guide/catalog-guide.html">
@@ -96,6 +96,7 @@
     }
   </style>
   <template>
+    <style include="iron-flex iron-flex-alignment"></style>
     <prism-highlighter></prism-highlighter>
 
     <catalog-data guides="{{guides}}"></catalog-data>
@@ -150,7 +151,7 @@
     contentChanged: function() {
       if (this.content.indexOf('<!doctype') >= 0) {
         this._catalogGuideError();
-      } else { console.log( this.content);
+      } else { 
         this.$.content.innerHTML = this.content;
         this._decorateHeadings();
         this._highlight();

--- a/app/elements/pages/page-not-found.html
+++ b/app/elements/pages/page-not-found.html
@@ -5,7 +5,7 @@
 
 <dom-module id="page-not-found">
   <template>
-    <style>
+    <style include="iron-flex iron-flex-alignment">
       paper-toolbar {
         background-color: white;
       }

--- a/app/elements/pages/page-packages.css
+++ b/app/elements/pages/page-packages.css
@@ -49,13 +49,6 @@ a.package {
   left: 15px;
 }
 
-@media (max-width: 639px) {
-  paper-toolbar /deep/ #topBar {
-    margin-top: 4px;
-    padding: 0 16px;
-  }
-}
-
 guide-card, #coming-soon {
   width: 456px;
   cursor: pointer;

--- a/app/elements/pages/page-packages.html
+++ b/app/elements/pages/page-packages.html
@@ -10,6 +10,7 @@
 <dom-module id="page-packages">
   <link rel="import" type="css" href="page-packages.css">
   <template>
+    <style include="iron-flex iron-flex-alignment iron-positioning"></style>
     <catalog-data packages="{{packages}}" guides="{{guides}}"></catalog-data>
     <paper-header-panel mode="seamed" class="fit">
       <paper-toolbar class="paper-header">
@@ -31,7 +32,7 @@
             <template is="dom-repeat" items="[[guides]]">
               <a href$="[[_link('guides',item.name)]]" is="app-link"><guide-card guide="[[item.name]]"></guide-card></a>
             </template>
-            <div id="coming-soon">More guides coming soon, stay tuned!</div>  
+            <div id="coming-soon">More guides coming soon, stay tuned!</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
It looks the same for me, but I would appreciate it if you could also run it locally to make sure I didn't miss anything.

Basically I:
- removed the explicit `/deep/` styling. It doesn't seem to make a difference
- replaced the old `classes/iron-flex-layout` classes with the new approach
- `hero-image` isn't an element that seems to be used, but I was too much of a chicken to delete it
- found a spurious `console.log` that printed the whole html content for guides to the console, and I don't think it was intended
