### PR TITLE
Indicate iron-positioning for fullbleed

### DIFF
--- a/guides/flex-layout.md
+++ b/guides/flex-layout.md
@@ -826,6 +826,8 @@ be achieved in CSS very simply:
       height: 100vh;
     }
 
+This class is included in the `iron-positioning` module of the `iron-flex-layout-classes` file.
+
 Note that the `fullbleed` class **only works on the `<body>` tag.** This is the only rule in the
 stylesheet that is scoped to a particular tag.
 


### PR DESCRIPTION
The layout guide for `fullbleed` was missing a reference to the `iron-positioning` module, leaving it up to the user to determine how to use it. This patch adds the appropriate reference.