### PR TITLE
Support for absolute bower URLs

### DIFF
--- a/app/elements/pages/page-element.html
+++ b/app/elements/pages/page-element.html
@@ -150,7 +150,11 @@
       return this.view === 'demo:' + path;
     },
     _githubLink: function(source) {
-      return 'https://github.com/' + source;
+      if(source && source.trim().substring(0, 4) === 'http'){
+        return source;
+      } else {
+        return 'https://github.com/' + source;
+      }
     },
     getURL: function(active,view,force) {
       var url = "/elements/" + this.element;


### PR DESCRIPTION
If bower dependencys are saved as URLs (https://bower.io/#install-packages) instead of Github shorthands the `Source` link in the UI breaks.
This is because 'https://github.com/' is always appanded to the front of the source, even if its already a hyperlink.

This fix enables URLs in bower dependencies, even to private github enterprise servers like: 
```javascript
"dependencies": {
    "my-element": "https://github.customdomain.com/elements/my-element.git#^1.0.0"
}