### PR TITLE
Changing the syntax of the `@apply` function

### DIFF
--- a/guides/flex-layout.md
+++ b/guides/flex-layout.md
@@ -164,8 +164,8 @@ main document. (They cannot be applied in the main document without a `custom-st
       <!-- main document -- apply mixins in a custom-style element -->
       <style is="custom-style">
         .container {
-          @apply(--layout-horizontal);
-          @apply(--layout-wrap);
+          @apply --layout-horizontal;
+          @apply --layout-wrap;
         }
       </style>
 
@@ -191,8 +191,8 @@ main document. (They cannot be applied in the main document without a `custom-st
       <!-- inside an element -- apply mixins in a standard style element -->
       <style>
         .container {
-          @apply(--layout-horizontal);
-          @apply(--layout-wrap);
+          @apply --layout-horizontal;
+          @apply --layout-wrap;
         }
       </style>
 
@@ -243,7 +243,7 @@ The classes listed here are included in the `iron-flex` module of the `iron-flex
 
       <style>
         .container {
-          @apply(--layout-horizontal);
+          @apply --layout-horizontal;
         }
       </style>
 
@@ -292,10 +292,10 @@ The classes listed here are included in the `iron-flex` module of the `iron-flex
 
       <style>
         .container {
-          @apply(--layout-horizontal);
+          @apply --layout-horizontal;
         }
         .flexchild {
-          @apply(--layout-flex);
+          @apply --layout-flex;
         }
       </style>
 
@@ -335,10 +335,10 @@ The same rules can be used for children in vertical layouts.
 
       <style>
         .container {
-          @apply(--layout-vertical);
+          @apply --layout-vertical;
         }
         .flexchild {
-          @apply(--layout-flex);
+          @apply --layout-flex;
         }
       </style>
 
@@ -387,16 +387,16 @@ The classes listed here are included in the `iron-flex-factors` module of the `i
 
       <style>
         .container {
-          @apply(--layout-horizontal);
+          @apply --layout-horizontal;
         }
         .flexchild {
-          @apply(--layout-flex);
+          @apply --layout-flex;
         }
         .flex2child {
-          @apply(--layout-flex-2);
+          @apply --layout-flex-2;
         }
         .flex3child {
-          @apply(--layout-flex-3);
+          @apply --layout-flex-3;
         }
       </style>
 
@@ -480,8 +480,8 @@ by adding the `center` class or applying the `--layout-center` mixin.
 
       <style>
         .container {
-          @apply(--layout-horizontal);
-          @apply(--layout-center);
+          @apply --layout-horizontal;
+          @apply --layout-center;
         }
       </style>
 
@@ -515,8 +515,8 @@ classes, or by applying the `--layout-start` or `--layout-end` mixins.
 
       <style>
         .container {
-          @apply(--layout-horizontal);
-          @apply(--layout-start);
+          @apply --layout-horizontal;
+          @apply --layout-start;
         }
       </style>
 
@@ -547,8 +547,8 @@ classes, or by applying the `--layout-start` or `--layout-end` mixins.
 
       <style>
         .container {
-          @apply(--layout-horizontal);
-          @apply(--layout-end);
+          @apply --layout-horizontal;
+          @apply --layout-end;
         }
       </style>
 
@@ -601,8 +601,8 @@ The classes listed here are included in the `iron-flex-alignment` module of the 
 
       <style>
         .container {
-          @apply(--layout-horizontal);
-          @apply(--layout-center-justified);
+          @apply --layout-horizontal;
+          @apply --layout-center-justified;
         }
       </style>
 
@@ -638,8 +638,8 @@ The classes listed here are included in the `iron-flex-alignment` module of the 
 
       <style>
         .container {
-          @apply(--layout-horizontal);
-          @apply(--layout-justified);
+          @apply --layout-horizontal;
+          @apply --layout-justified;
         }
       </style>
 
@@ -699,24 +699,24 @@ Class | Mixin | Result
 
       <style>
         .container {
-          @apply(--layout-horizontal);
-          @apply(--layout-justified);
+          @apply --layout-horizontal;
+          @apply --layout-justified;
           height: 120px;
         }
         .container div {
-          @apply(--layout-flex);
+          @apply --layout-flex;
         }
         .child1 {
-          @apply(--layout-self-start);
+          @apply --layout-self-start;
         }
         .child2 {
-          @apply(--layout-self-center);
+          @apply --layout-self-center;
         }
         .child3 {
-          @apply(--layout-self-end);
+          @apply --layout-self-end;
         }
         .child4 {
-          @apply(--layout-self-stretch);
+          @apply --layout-self-stretch;
         }
       </style>
 
@@ -785,7 +785,7 @@ The classes listed here are included in the `iron-flex-reverse` module of the `i
 
       <style>
         .container {
-          @apply(--layout-horizontal-reverse);
+          @apply --layout-horizontal-reverse;
         }
       </style>
 


### PR DESCRIPTION
The `@apply()` syntax isdeprecated (because it goes against the CSS spec)