### PR TITLE
Add deprecation notice in favor of webcomponents.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Polymer Element Catalog
 
-**:warning: This catalog is no longer maintained. There is a non-Polymer specific catalog available on https://www.webcomponents.org/ :warning:**
+**:warning: This catalog is no longer maintained. There is a non-Polymer specific catalog available on https://www.webcomponents.org/ A self-hosting catalog is available at https://github.com/PolymerLabs/indie-catalog :warning:**
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Polymer Element Catalog
 
+**:warning: This catalog is no longer maintained. There is a non-Polymer specific catalog available on https://www.webcomponents.org/ :warning:**
+
 ## Getting Started
 
 To work on the Polymer Elements Catalog, clone the repository.


### PR DESCRIPTION
As this repository is no longer maintained, add a deprecation notice in favor of https://www.webcomponents.org/